### PR TITLE
Update README with ivgfiddle link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ The renderer relies only on the included **NuXPixels** library and provides high
 format IVG-2 requires:ImpD-1
 ```
 
-Instructions cover shapes, paths, images and text as well as directives for styling and transformations. See `docs/IVG Documentation.md` and `docs/ImpD Documentation.md` for the complete specification.
+Instructions cover shapes, paths, images and text as well as directives for styling and transformations. See
+[`IVG Documentation`](docs/IVG%20Documentation.md) and
+[`ImpD Documentation`](docs/ImpD%20Documentation.md) for the complete specification.
 
-For integration details and API examples, see `docs/Developer Guide.md`.
+For integration details and API examples, see
+[`Developer Guide`](docs/Developer%20Guide.md).
+
+### IVGFiddle
+
+Included in this distribution is a standalone .html application called _IVGFiddle_. You can run it simply by opening the
+[`ivgfiddle.html`][ivgfiddle-link] file in your favorite browser (Google Chrome). It will let you experiment with IVG code
+and see the graphical output in real-time.
+
+[ivgfiddle-link]: https://htmlpreview.github.io/?https://github.com/malstrom72/IVG/blob/main/tools/ivgfiddle/output/ivgfiddle.html


### PR DESCRIPTION
## Summary
- fix README IVGFiddle link using GitHub `blob` path so htmlpreview works once the repo is public

## Testing
- `timeout 120 ./build.sh beta native nosimd`


------
https://chatgpt.com/codex/tasks/task_e_686cf46075d48332950be1c79389b391