### PR TITLE
Improve SpanBuffer explanation

### DIFF
--- a/externals/NuX/NuXPixels.h
+++ b/externals/NuX/NuXPixels.h
@@ -489,6 +489,12 @@ inline Mask8::Pixel Mask8::join(const UInt8 components[COMPONENT_COUNT]) { retur
 
 inline Mask8::Pixel convert(const ARGB32&, const Mask8&, ARGB32::Pixel source) { return source >> 24; }
 inline ARGB32::Pixel convert(const Mask8&, const ARGB32&, Mask8::Pixel source) { return (source << 24) | (source << 16) | (source << 8) | source; }
+/**
+       Span models a run of consecutive pixels. The run length and the "solid"
+       and "opaque" flags are packed into a 32-bit field. When the span is solid,
+       \p pixels points to a single color repeated for the entire run; otherwise
+       it addresses an array containing one pixel per position.
+**/
 
 template<class T> class Span {
 	public:		Span();
@@ -512,6 +518,16 @@ template<class T> class Span {
 	#define NUXPIXELS_SPAN_ARRAY(T, n) NuXPixels::Span<T> (n)[NuXPixels::MAX_RENDER_LENGTH];
 #endif
 
+/**
+       SpanBuffer stores runs of pixels in two parallel arrays. When a span of
+       length \p n is added, \p n entries are reserved in the span array. The
+       first entry holds the span itself while the last entry duplicates it so
+       the iterator can read the previous span's length when stepping
+       backwards. Entries in between are unused but make pointer arithmetic work
+       for both forward and backward iteration. Pixel data are appended to the
+       pixel array in tandem—a solid span stores one color, whereas a variable
+       span stores \p n colors.
+**/
 template<class T> class SpanBuffer {
 	public:		class iterator;
 #if (NUXPIXELS_ICC_HACK)

--- a/externals/NuX/NuXPixelsImpl.h
+++ b/externals/NuX/NuXPixelsImpl.h
@@ -247,7 +247,9 @@ template<class T> const typename T::Pixel* Span<T>::getPixelPointer() const { re
 /* --- SpanBuffer --- */
 
 /**
-	Iterator walks spans in a SpanBuffer sequentially.
+        Iterator walks spans in a SpanBuffer sequentially. Incrementing advances
+        by the length of the current span, while decrementing relies on the copy
+        stored at the end of the previous span to step backwards.
 **/
 template<class T> class SpanBuffer<T>::iterator {
 	public:		iterator(Span<T>* p) : p(p) { }


### PR DESCRIPTION
## Summary
- clarify how SpanBuffer reserves span slots and pixels

## Testing
- `clang-format -n --Werror externals/NuX/NuXPixels.h externals/NuX/NuXPixelsImpl.h` *(fails: code should be clang-formatted)*
- `timeout 120 ./build.sh beta native nosimd`

------
https://chatgpt.com/codex/tasks/task_e_686d97d51d3c8332ac0b17efa88a1fea