### PR TITLE
Mark ivgfiddle output as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Mark generated files from IVG Fiddle build as linguist-generated
+/tools/ivgfiddle/output/** linguist-generated=true
+/tools/ivgfiddle/src/rasterizeIVG.js linguist-generated=true


### PR DESCRIPTION
## Summary
- tell GitHub Linguist to ignore ivgfiddle build output

## Testing
- `timeout 120 ./build.sh beta native nosimd`

------
https://chatgpt.com/codex/tasks/task_e_686e62b1036083328bbb6cd427e99ec4