### PR TITLE
Handle spaces in Windows IVG test scripts

### DIFF
--- a/tools/testIVG.bat
+++ b/tools/testIVG.bat
@@ -15,8 +15,8 @@ MKDIR %tempDir%
 FOR %%f IN (ivg\*.ivg) DO (
 	ECHO Doing %%f
 	ECHO.
-	%exe% %%f %tempDir%\%%~nf.png || GOTO error
-	fc %tempDir%\%%~nf.png png\%%~nf.png || GOTO error
+	%exe% "%%f" "%tempDir%\%%~nf.png" || GOTO error
+	fc "%tempDir%\%%~nf.png" "png\%%~nf.png" || GOTO error
 	ECHO.
 	ECHO.
 )

--- a/tools/updateIVGTests.bat
+++ b/tools/updateIVGTests.bat
@@ -9,11 +9,11 @@ IF "%~1"=="" (
 )
 
 FOR %%f IN (ivg\*.ivg) DO (
-        ECHO Doing %%f
-        ECHO.
-        %exe% %%f png\%%~nf.png || GOTO BAD
-        ECHO.
-        ECHO.
+	ECHO Doing %%f
+	ECHO.
+	%exe% "%%f" "png\%%~nf.png" || GOTO BAD
+	ECHO.
+	ECHO.
 )
 GOTO END
 


### PR DESCRIPTION
## Summary
- quote paths in `testIVG.bat` and `updateIVGTests.bat`
- keep indentation with tabs as required

## Testing
- `timeout 120 ./build.sh beta native nosimd > /tmp/build.log && tail -n 20 /tmp/build.log`

------
https://chatgpt.com/codex/tasks/task_e_68711ee6b87c8332a6547cbd9ee3f5a1