### PR TITLE
Fix build.sh failure on Linux

### DIFF
--- a/externals/NuX/NuXSIMD.h
+++ b/externals/NuX/NuXSIMD.h
@@ -11,8 +11,8 @@
 
 #if defined(_MSC_VER) // Visual C++ version
 
-        #define NUXSIMD_WIN 1
-        #define NUXSIMD_POSIX 0 // macOS/Linux
+    #define NUXSIMD_WIN 1
+    #define NUXSIMD_UNIX 0 // macOS/Linux
 	#define NUXSIMD_BIG_ENDIAN 0
 	#define NUXSIMD_LITTLE_ENDIAN 1
 	#define NUXSIMD_INLINE __forceinline
@@ -22,38 +22,26 @@
 	
 #elif defined(__APPLE__) || defined(__linux__) // Unix-like (macOS/Linux)
 
-        #define NUXSIMD_WIN 0
-        #define NUXSIMD_POSIX 1 // macOS/Linux
+	#define NUXSIMD_WIN 0
+	#define NUXSIMD_UNIX 1 // macOS/Linux
 	#if (__ARM_NEON__)
 		#define NUXSIMD_BIG_ENDIAN 0
 		#define NUXSIMD_LITTLE_ENDIAN 1
     	#define NUXSIMD_ALTIVEC 0
 		#define NUXSIMD_NEON 1
 		#define NUXSIMD_SSE 0
-#elif (__LITTLE_ENDIAN__)
-	#define NUXSIMD_BIG_ENDIAN 0
-	#define NUXSIMD_LITTLE_ENDIAN 1
-	#define NUXSIMD_ALTIVEC 0
-	#define NUXSIMD_NEON 0
-	#define NUXSIMD_SSE 1
-#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
-	#define NUXSIMD_BIG_ENDIAN 0
-	#define NUXSIMD_LITTLE_ENDIAN 1
-	#define NUXSIMD_ALTIVEC 0
-	#define NUXSIMD_NEON 0
-	#define NUXSIMD_SSE 1
-#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
-	#define NUXSIMD_BIG_ENDIAN 1
-	#define NUXSIMD_LITTLE_ENDIAN 0
-	#define NUXSIMD_ALTIVEC 1
-	#define NUXSIMD_NEON 0
-	#define NUXSIMD_SSE 0
-#elif (__BIG_ENDIAN__)
-	#define NUXSIMD_BIG_ENDIAN 1
-	#define NUXSIMD_LITTLE_ENDIAN 0
-	#define NUXSIMD_ALTIVEC 1
-	#define NUXSIMD_NEON 0
-	#define NUXSIMD_SSE 0
+	#elif (__LITTLE_ENDIAN__) || (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+		#define NUXSIMD_BIG_ENDIAN 0
+		#define NUXSIMD_LITTLE_ENDIAN 1
+		#define NUXSIMD_ALTIVEC 0
+		#define NUXSIMD_NEON 0
+		#define NUXSIMD_SSE 1
+	#elif (__BIG_ENDIAN__) || (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+		#define NUXSIMD_BIG_ENDIAN 1
+		#define NUXSIMD_LITTLE_ENDIAN 0
+		#define NUXSIMD_ALTIVEC 1
+		#define NUXSIMD_NEON 0
+		#define NUXSIMD_SSE 0
 	#endif
 	#define NUXSIMD_INLINE inline __attribute__((always_inline))
 	
@@ -81,14 +69,14 @@ namespace NuXSIMD {
 
 #if (NUXSIMD_WIN)
 	#define SIMD_ALIGN(x) __declspec(align(16)) x
-#elif (NUXSIMD_POSIX)
+#elif (NUXSIMD_UNIX)
         #define SIMD_ALIGN(x) x __attribute__ ((aligned (16)))
-#endif // (NUXSIMD_POSIX)
+#endif // (NUXSIMD_UNIX)
 
 NUXSIMD_INLINE bool isAligned(const void* p) { return ((reinterpret_cast<intptr_t>(p) & 0xF) == 0); }
 template<typename T> NUXSIMD_INLINE T* allocateAligned(size_t size) {
 	const size_t bytes = ((size * sizeof (T) + 15) & ~15U);
-#if (NUXSIMD_NEON || NUXSIMD_POSIX)
+#if (NUXSIMD_NEON || NUXSIMD_UNIX)
         T* alloced = reinterpret_cast<T*>(aligned_alloc(16, bytes));
 #else
         T* alloced = reinterpret_cast<T*>(_mm_malloc(bytes, 16));
@@ -101,7 +89,7 @@ template<typename T> NUXSIMD_INLINE T* allocateAligned(size_t size) {
 }
 NUXSIMD_INLINE void freeAligned(void* p) {
 	assert(p != 0);
-#if (NUXSIMD_NEON || NUXSIMD_POSIX)
+#if (NUXSIMD_NEON || NUXSIMD_UNIX)
         free(p);
 #else
         _mm_free(p);


### PR DESCRIPTION
## Summary
- update SIMD detection to use `__BYTE_ORDER__` macros when `__LITTLE_ENDIAN__` is not defined

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873ca5d410c8332bcf6cfbb92f428ed