### PR TITLE
Add scripts to copy resvg PNG references

### DIFF
--- a/copyResvgPngs.cmd
+++ b/copyResvgPngs.cmd
@@ -1,0 +1,18 @@
+@ECHO OFF
+CD /D "%~dp0"
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+FOR /R tests\svg %%F IN (*.svg) DO (
+	SET "base=%%~nF"
+	IF "!base:~0,12!"=="resvg_tests_" (
+		SET "rest=!base:~12!"
+		SET "rel=!rest:_=\!"
+		SET "src=externals\resvgTests\!rel!.png"
+		IF EXIST "!src!" (
+			COPY /Y "!src!" "%%~dpF%%~nF.png" >NUL
+		) ELSE (
+			>&2 ECHO missing "!src!"
+		)
+	)
+)
+EXIT /b 0

--- a/copyResvgPngs.sh
+++ b/copyResvgPngs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e -o pipefail -u
+
+cd "$(dirname "$0")"
+
+find tests/svg -type f -name '*.svg' | while IFS= read -r svg; do
+	base=$(basename "$svg")
+	[[ $base == resvg_tests_* ]] || continue
+	name=${base%.svg}
+	rest=${name#resvg_tests_}
+	rel=${rest//_/\/}
+	src="externals/resvgTests/$rel.png"
+	if [[ -f $src ]]; then
+		cp "$src" "$(dirname "$svg")/$name.png"
+	else
+		echo "missing $src" >&2
+	fi
+done


### PR DESCRIPTION
## Summary
- add `copyResvgPngs.sh` to mirror PNGs from `externals/resvgTests` next to SVG tests
- add Windows `copyResvgPngs.cmd` counterpart

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_689c7f3baf548332ad94c2d09040ec99