### PR TITLE
Enforce initial M in SVG paths

### DIFF
--- a/src/IVG.cpp
+++ b/src/IVG.cpp
@@ -139,7 +139,14 @@ bool buildPathFromSVG(const String& svgSource, double curveQuality, Path& path, 
 	StringIt e = svgSource.end();
 	Vertex quadraticReflectionPoint;
 	Vertex cubicReflectionPoint;
-	
+
+	p = eatSpace(p, e);
+	if (p == e) return true;
+	if (*p != 'M' && *p != 'm') {
+		errorString = "SVG path must begin with 'M'";
+		return false;
+	}
+
 	while (p != e) {
 		p = eatSpace(p, e);
 		if (p != e) {


### PR DESCRIPTION
## Summary
- validate that SVG paths start with `M` or `m`
- remove standalone SVGPathTest harness from build process

## Testing
- `timeout 180 ./build.sh` *(truncated output)*
- `./output/IVG2PNG /tmp/invalid.ivg /tmp/out.png` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_689caf0693bc8332b833c689ce20b585