### PR TITLE
Preserve color formats in svg2ivg

### DIFF
--- a/tools/svg2ivg/svg2ivg.js
+++ b/tools/svg2ivg/svg2ivg.js
@@ -81,6 +81,53 @@ r = c; g = 0; b = x;
 return { r: (r + m) * 255, g: (g + m) * 255, b: (b + m) * 255 };
 }
 
+function hsvToRgb(h, s, v) {
+h = ((h % 360) + 360) % 360 / 60;
+s = Math.max(0, Math.min(1, s));
+v = Math.max(0, Math.min(1, v));
+const c = v * s;
+const x = c * (1 - Math.abs(h % 2 - 1));
+const m = v - c;
+let r, g, b;
+if (h < 1) {
+r = c; g = x; b = 0;
+} else if (h < 2) {
+r = x; g = c; b = 0;
+} else if (h < 3) {
+r = 0; g = c; b = x;
+} else if (h < 4) {
+r = 0; g = x; b = c;
+} else if (h < 5) {
+r = x; g = 0; b = c;
+} else {
+r = c; g = 0; b = x;
+}
+return { r: (r + m) * 255, g: (g + m) * 255, b: (b + m) * 255 };
+}
+
+function parseRgbComponent(str) {
+const percentage = str.trim().endsWith('%');
+let num = parseFloat(str);
+if (percentage) {
+num = 255 * num / 100;
+} else if (num <= 1) {
+num *= 255;
+}
+return num;
+}
+
+function parseAlpha(str) {
+		if (str.trim().endsWith('%')) {
+				return parseFloat(str) / 100;
+		}
+		const num = parseFloat(str);
+		return num > 1 ? num / 255 : num;
+}
+
+function formatFloat(num) {
+		return parseFloat(num.toFixed(6)).toString();
+}
+
 const SVG_COLORS = {
 	aliceblue:"#f0f8ff",antiquewhite:"#faebd7",aquamarine:"#7fffd4",azure:"#f0ffff",beige:"#f5f5dc",bisque:"#ffe4c4",blanchedalmond:"#ffebcd",blueviolet:"#8a2be2",brown:"#a52a2a",burlywood:"#deb887",cadetblue:"#5f9ea0",chartreuse:"#7fff00",chocolate:"#d2691e",coral:"#ff7f50",cornflowerblue:"#6495ed",cornsilk:"#fff8dc",crimson:"#dc143c",cyan:"#00ffff",darkblue:"#00008b",darkcyan:"#008b8b",darkgoldenrod:"#b8860b",darkgray:"#a9a9a9",darkgreen:"#006400",darkgrey:"#a9a9a9",darkkhaki:"#bdb76b",darkmagenta:"#8b008b",darkolivegreen:"#556b2f",darkorange:"#ff8c00",darkorchid:"#9932cc",darkred:"#8b0000",darksalmon:"#e9967a",darkseagreen:"#8fbc8f",darkslateblue:"#483d8b",darkslategray:"#2f4f4f",darkslategrey:"#2f4f4f",darkturquoise:"#00ced1",darkviolet:"#9400d3",deeppink:"#ff1493",deepskyblue:"#00bfff",dimgray:"#696969",dimgrey:"#696969",dodgerblue:"#1e90ff",firebrick:"#b22222",floralwhite:"#fffaf0",forestgreen:"#228b22",gainsboro:"#dcdcdc",ghostwhite:"#f8f8ff",gold:"#ffd700",goldenrod:"#daa520",grey:"#808080",greenyellow:"#adff2f",honeydew:"#f0fff0",hotpink:"#ff69b4",indianred:"#cd5c5c",indigo:"#4b0082",ivory:"#fffff0",khaki:"#f0e68c",lavender:"#e6e6fa",lavenderblush:"#fff0f5",lawngreen:"#7cfc00",lemonchiffon:"#fffacd",lightblue:"#add8e6",lightcoral:"#f08080",lightcyan:"#e0ffff",lightgoldenrodyellow:"#fafad2",lightgray:"#d3d3d3",lightgreen:"#90ee90",lightgrey:"#d3d3d3",lightpink:"#ffb6c1",lightsalmon:"#ffa07a",lightseagreen:"#20b2aa",lightskyblue:"#87cefa",lightslategray:"#778899",lightslategrey:"#778899",lightsteelblue:"#b0c4de",lightyellow:"#ffffe0",limegreen:"#32cd32",linen:"#faf0e6",magenta:"#ff00ff",mediumaquamarine:"#66cdaa",mediumblue:"#0000cd",mediumorchid:"#ba55d3",mediumpurple:"#9370db",mediumseagreen:"#3cb371",mediumslateblue:"#7b68ee",mediumspringgreen:"#00fa9a",mediumturquoise:"#48d1cc",mediumvioletred:"#c71585",midnightblue:"#191970",mintcream:"#f5fffa",mistyrose:"#ffe4e1",moccasin:"#ffe4b5",navajowhite:"#ffdead",oldlace:"#fdf5e6",olivedrab:"#6b8e23",orange:"#ffa500",orangered:"#ff4500",orchid:"#da70d6",palegoldenrod:"#eee8aa",palegreen:"#98fb98",paleturquoise:"#afeeee",palevioletred:"#db7093",papayawhip:"#ffefd5",peachpuff:"#ffdab9",peru:"#cd853f",pink:"#ffc0cb",plum:"#dda0dd",powderblue:"#b0e0e6",rosybrown:"#bc8f8f",royalblue:"#4169e1",saddlebrown:"#8b4513",salmon:"#fa8072",sandybrown:"#f4a460",seagreen:"#2e8b57",seashell:"#fff5ee",sienna:"#a0522d",skyblue:"#87ceeb",slateblue:"#6a5acd",slategray:"#708090",slategrey:"#708090",snow:"#fffafa",springgreen:"#00ff7f",steelblue:"#4682b4",tan:"#d2b48c",thistle:"#d8bfd8",tomato:"#ff6347",turquoise:"#40e0d0",violet:"#ee82ee",wheat:"#f5deb3",whitesmoke:"#f5f5f5",yellowgreen:"#9acd32"
 };
@@ -89,61 +136,107 @@ const BASIC_COLORS = {aqua:'#00ffff', black:'#000000', blue:'#0000ff', fuchsia:'
 const gradients = {};
 
 function convertPaint(sourcePaint) {
-	sourcePaint = sourcePaint.trim().toLowerCase();
-	if (sourcePaint.startsWith('url(')) {
-		let id = sourcePaint.slice(4, -1).trim();
-		if (id.startsWith('#')) {
-			id = id.slice(1);
+		sourcePaint = sourcePaint.trim().toLowerCase();
+		if (sourcePaint.startsWith('url(')) {
+				let id = sourcePaint.slice(4, -1).trim();
+				if (id.startsWith('#')) {
+						id = id.slice(1);
+				}
+				if (!(id in gradients)) {
+						throw new Error('Unrecognized paint reference: ' + sourcePaint);
+				}
+				return { paint: buildGradient(gradients[id]), opacity: 1 };
 		}
-		if (!(id in gradients)) {
-			throw new Error('Unrecognized paint reference: ' + sourcePaint);
+		if (sourcePaint === 'none') {
+				return { paint: 'none', opacity: 1 };
 		}
-		return { paint: buildGradient(gradients[id]), opacity: 1 };
-	}
-	if (sourcePaint === 'none') {
-		return { paint: 'none', opacity: 1 };
-	}
-	if (/^#[0-9a-f]{6}$/.test(sourcePaint)) {
-		return { paint: sourcePaint, opacity: 1 };
-	}
-	const rgb3 = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i;
-	let m = sourcePaint.match(rgb3);
-	if (m) {
-		return { paint: '#' + m[1] + m[1] + m[2] + m[2] + m[3] + m[3], opacity: 1 };
-	}
-	m = sourcePaint.match(/^rgba\(([^)]+)\)$/);
-	if (m) {
-		const nums = m[1].split(/[ ,]+/);
-		if (nums.length !== 4) throw new Error('Invalid rgba color: ' + sourcePaint);
-		return { paint: rgbToHex(parseFloat(nums[0]), parseFloat(nums[1]), parseFloat(nums[2])), opacity: parseFloat(nums[3]) };
-	}
-	m = sourcePaint.match(/^rgb\(([^)]+)\)$/);
-	if (m) {
-		const nums = m[1].split(/[ ,]+/);
-		if (nums.length !== 3) throw new Error('Invalid rgb color: ' + sourcePaint);
-		return { paint: rgbToHex(parseFloat(nums[0]), parseFloat(nums[1]), parseFloat(nums[2])), opacity: 1 };
-	}
-	m = sourcePaint.match(/^hsla\(([^)]+)\)$/);
-	if (m) {
-		const nums = m[1].split(/[ ,]+/);
-		if (nums.length !== 4) throw new Error('Invalid hsla color: ' + sourcePaint);
-		const rgb = hslToRgb(parseFloat(nums[0]), parseFloat(nums[1]) / 100, parseFloat(nums[2]) / 100);
-		return { paint: rgbToHex(rgb.r, rgb.g, rgb.b), opacity: parseFloat(nums[3]) };
-	}
-	m = sourcePaint.match(/^hsl\(([^)]+)\)$/);
-	if (m) {
-		const nums = m[1].split(/[ ,]+/);
-		if (nums.length !== 3) throw new Error('Invalid hsl color: ' + sourcePaint);
-		const rgb = hslToRgb(parseFloat(nums[0]), parseFloat(nums[1]) / 100, parseFloat(nums[2]) / 100);
-		return { paint: rgbToHex(rgb.r, rgb.g, rgb.b), opacity: 1 };
-	}
-	if (sourcePaint in BASIC_COLORS) {
-		return { paint: BASIC_COLORS[sourcePaint], opacity: 1 };
-	}
-	if (sourcePaint in SVG_COLORS) {
-		return { paint: SVG_COLORS[sourcePaint], opacity: 1 };
-	}
-	throw new Error('Unrecognized color: ' + sourcePaint);
+		if (/^#[0-9a-f]{6}$/.test(sourcePaint)) {
+				return { paint: sourcePaint, opacity: 1 };
+		}
+		const rgb3 = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i;
+		let m = sourcePaint.match(rgb3);
+		if (m) {
+				return { paint: '#' + m[1] + m[1] + m[2] + m[2] + m[3] + m[3], opacity: 1 };
+		}
+		m = sourcePaint.match(/^#([0-9a-f]{8})$/);
+		if (m) {
+				const r = parseInt(m[1].slice(0, 2), 16);
+				const g = parseInt(m[1].slice(2, 4), 16);
+				const b = parseInt(m[1].slice(4, 6), 16);
+				const a = parseInt(m[1].slice(6, 8), 16) / 255;
+				return { paint: rgbToHex(r, g, b), opacity: a };
+		}
+		m = sourcePaint.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f])$/i);
+		if (m) {
+				const r = parseInt(m[1] + m[1], 16);
+				const g = parseInt(m[2] + m[2], 16);
+				const b = parseInt(m[3] + m[3], 16);
+				const a = parseInt(m[4] + m[4], 16) / 255;
+				return { paint: rgbToHex(r, g, b), opacity: a };
+		}
+		m = sourcePaint.match(/^rgba\(([^)]+)\)$/);
+		if (m) {
+				const nums = m[1].split(/[ ,]+/);
+				if (nums.length !== 4) throw new Error('Invalid rgba color: ' + sourcePaint);
+				const r = +(parseRgbComponent(nums[0]) / 255).toFixed(6);
+				const g = +(parseRgbComponent(nums[1]) / 255).toFixed(6);
+				const b = +(parseRgbComponent(nums[2]) / 255).toFixed(6);
+				return { paint: `rgb(${r},${g},${b})`, opacity: parseAlpha(nums[3]) };
+		}
+		m = sourcePaint.match(/^rgb\(([^)]+)\)$/);
+		if (m) {
+				const nums = m[1].split(/[ ,]+/);
+				if (nums.length !== 3) throw new Error('Invalid rgb color: ' + sourcePaint);
+				const r = +(parseRgbComponent(nums[0]) / 255).toFixed(6);
+				const g = +(parseRgbComponent(nums[1]) / 255).toFixed(6);
+				const b = +(parseRgbComponent(nums[2]) / 255).toFixed(6);
+				return { paint: `rgb(${r},${g},${b})`, opacity: 1 };
+		}
+		m = sourcePaint.match(/^hsla\(([^)]+)\)$/);
+		if (m) {
+				const nums = m[1].split(/[ ,]+/);
+				if (nums.length !== 4) throw new Error('Invalid hsla color: ' + sourcePaint);
+				const rgb = hslToRgb(parseFloat(nums[0]), parseFloat(nums[1]) / 100, parseFloat(nums[2]) / 100);
+				const r = +(rgb.r / 255).toFixed(6);
+				const g = +(rgb.g / 255).toFixed(6);
+				const b = +(rgb.b / 255).toFixed(6);
+				return { paint: `rgb(${r},${g},${b})`, opacity: parseAlpha(nums[3]) };
+		}
+		m = sourcePaint.match(/^hsl\(([^)]+)\)$/);
+		if (m) {
+				const nums = m[1].split(/[ ,]+/);
+				if (nums.length !== 3) throw new Error('Invalid hsl color: ' + sourcePaint);
+				const rgb = hslToRgb(parseFloat(nums[0]), parseFloat(nums[1]) / 100, parseFloat(nums[2]) / 100);
+				const r = +(rgb.r / 255).toFixed(6);
+				const g = +(rgb.g / 255).toFixed(6);
+				const b = +(rgb.b / 255).toFixed(6);
+				return { paint: `rgb(${r},${g},${b})`, opacity: 1 };
+		}
+		m = sourcePaint.match(/^hsva\(([^)]+)\)$/);
+		if (m) {
+				const nums = m[1].split(/[ ,]+/);
+				if (nums.length !== 4) throw new Error('Invalid hsva color: ' + sourcePaint);
+				const h = +(parseFloat(nums[0]) / 360).toFixed(6);
+				const s = +(parseFloat(nums[1]) / 100).toFixed(6);
+				const v = +(parseFloat(nums[2]) / 100).toFixed(6);
+				return { paint: `hsv(${h},${s},${v})`, opacity: parseAlpha(nums[3]) };
+		}
+		m = sourcePaint.match(/^hsv\(([^)]+)\)$/);
+		if (m) {
+				const nums = m[1].split(/[ ,]+/);
+				if (nums.length !== 3) throw new Error('Invalid hsv color: ' + sourcePaint);
+				const h = +(parseFloat(nums[0]) / 360).toFixed(6);
+				const s = +(parseFloat(nums[1]) / 100).toFixed(6);
+				const v = +(parseFloat(nums[2]) / 100).toFixed(6);
+				return { paint: `hsv(${h},${s},${v})`, opacity: 1 };
+		}
+		if (sourcePaint in BASIC_COLORS) {
+				return { paint: sourcePaint, opacity: 1 };
+		}
+		if (sourcePaint in SVG_COLORS) {
+				return { paint: SVG_COLORS[sourcePaint], opacity: 1 };
+		}
+		throw new Error('Unrecognized color: ' + sourcePaint);
 }
 
 const definitions = {};
@@ -220,29 +313,38 @@ function parseGradientCoord(value, axis) {
 }
 
 function parseGradientStops(element) {
-	const stops = [];
-	for (const item of element.contents || []) {
-		if (item.element && item.element.type === 'stop') {
-			const a = item.element.attributes;
-			if (!('offset' in a) || !('stop-color' in a)) continue;
-			let o = a.offset.trim();
-			o = o.endsWith('%') ? parseFloat(o) / 100 : parseFloat(o);
-			const p = convertPaint(a['stop-color']);
-			let op = p.opacity;
-			if ('stop-opacity' in a) {
-				op *= convertOpacity(a['stop-opacity']);
-			}
-			let color = p.paint;
-			if (op !== 1) {
-				const alpha = Math.round(op * 255).toString(16).padStart(2, '0');
-				if (color.startsWith('#')) {
-					color += alpha;
-					} else {
-						color = color + alpha;
-					}
+		const stops = [];
+		for (const item of element.contents || []) {
+				if (item.element && item.element.type === 'stop') {
+						const a = item.element.attributes;
+						if (!('offset' in a) || !('stop-color' in a)) continue;
+						let o = a.offset.trim();
+						o = o.endsWith('%') ? parseFloat(o) / 100 : parseFloat(o);
+						const p = convertPaint(a['stop-color']);
+						let op = p.opacity;
+						if ('stop-opacity' in a) {
+								op *= convertOpacity(a['stop-opacity']);
+						}
+						let color = p.paint;
+						if (op !== 1) {
+								if (color.startsWith('#')) {
+										const alpha = Math.round(op * 255).toString(16).padStart(2, '0');
+										color += alpha;
+								} else if (color.startsWith('rgb(') || color.startsWith('hsv(')) {
+										color = color.replace(/\)$/u, `,${formatFloat(op)})`);
+								} else if (color in BASIC_COLORS || color in SVG_COLORS) {
+										const hex = BASIC_COLORS[color] || SVG_COLORS[color];
+										const r = +(parseInt(hex.slice(1, 3), 16) / 255).toFixed(6);
+										const g = +(parseInt(hex.slice(3, 5), 16) / 255).toFixed(6);
+										const b = +(parseInt(hex.slice(5, 7), 16) / 255).toFixed(6);
+										color = `rgb(${r},${g},${b},${formatFloat(op)})`;
+								} else {
+										const alpha = Math.round(op * 255).toString(16).padStart(2, '0');
+										color += alpha;
+								}
+						}
+						stops.push({ offset: o, color });
 				}
-				stops.push({offset: o, color});
-			}
 		}
 		return stops;
 }


### PR DESCRIPTION
## Summary
- Avoid converting rgb/rgba/hsv/hsva inputs and IVG-supported color names into hex strings
- Normalize indentation in svg2ivg.js and handle gradient stop opacity for non-hex colors

## Testing
- `timeout 180 ./build.sh`
- `node tools/svg2ivg/svg2ivg.js tests/svg/supported/resvg_tests_paint-servers_stop_hsla-color.svg`
- `node tools/svg2ivg/svg2ivg.js /tmp/test_rgb_decimal.svg`
- `node tools/svg2ivg/svg2ivg.js /tmp/test_hsv.svg`
- `node tools/svg2ivg/svg2ivg.js /tmp/test_hsva.svg`
- `node tools/svg2ivg/svg2ivg.js /tmp/test_name.svg`


------
https://chatgpt.com/codex/tasks/task_e_689cb23ec04c8332a2672deca35c79cd