### PR TITLE
Use sans-serif font in test SVGs

### DIFF
--- a/tests/svg/supported/resvg_tests_text_font-size_simple-case.svg
+++ b/tests/svg/supported/resvg_tests_text_font-size_simple-case.svg
@@ -1,4 +1,4 @@
-<svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" font-family="Noto Sans">
+<svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" font-family="sans-serif">
     <title>Simple case</title>
 
     <text id="text1" x="100" y="100" text-anchor="middle" font-size="40">Text</text>

--- a/tests/svg/supported/resvg_tests_text_text-anchor_middle-on-text.svg
+++ b/tests/svg/supported/resvg_tests_text_text-anchor_middle-on-text.svg
@@ -1,5 +1,5 @@
 <svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"
-     font-family="Noto Sans" font-size="48">
+     font-family="sans-serif" font-size="48">
     <title>`middle` on `text`</title>
 
     <path id="crosshair" d="M 20 100 L 180 100 M 100 20 L 100 180"

--- a/tests/svg/supported/resvg_tests_text_tspan_tspan-bbox-1.svg
+++ b/tests/svg/supported/resvg_tests_text_tspan_tspan-bbox-1.svg
@@ -1,5 +1,5 @@
 <svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"
-     font-family="Noto Sans" font-size="24">
+     font-family="sans-serif" font-size="24">
     <title>`tspan` bbox (1)</title>
     <desc>`tspan` doesn't have a bbox and `text` bbox should be used</desc>
 

--- a/tests/svg/unsupported/resvg_tests_text_font-style_italic.svg
+++ b/tests/svg/unsupported/resvg_tests_text_font-style_italic.svg
@@ -1,5 +1,5 @@
 <svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"
-     font-family="Noto Sans" font-size="40">
+     font-family="sans-serif" font-size="40">
     <title>`italic`</title>
 
     <text id="text1" x="100" y="100" text-anchor="middle" font-style="italic">Text</text>

--- a/tests/svg/unsupported/resvg_tests_text_font-weight_bold.svg
+++ b/tests/svg/unsupported/resvg_tests_text_font-weight_bold.svg
@@ -1,5 +1,5 @@
 <svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"
-     font-family="Noto Sans" font-size="40" text-anchor="middle">
+     font-family="sans-serif" font-size="40" text-anchor="middle">
     <title>`bold`</title>
 
     <text id="text1" x="100" y="100" font-weight="bold">Text</text>

--- a/tests/svg/unsupported/resvg_tests_text_textPath_startOffset=30.svg
+++ b/tests/svg/unsupported/resvg_tests_text_textPath_startOffset=30.svg
@@ -5,7 +5,7 @@
     <path id="pathForText1" d="M 20 100 C 35 135 85 135 100 100 C 115 65 165 65 180 100"
           fill="none" stroke="gray"/>
 
-    <text id="text1" font-family="Noto Sans" font-size="24">
+    <text id="text1" font-family="sans-serif" font-size="24">
         <textPath id="textPath1" xlink:href="#pathForText1" startOffset="30">
             Some long text
         </textPath>


### PR DESCRIPTION
## Summary
- replace `Noto Sans` with `sans-serif` in test SVG files

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_689dc2b6da7c8332be5f8166e4a31236