### PR TITLE
Add svg2ivg conversion tests

### DIFF
--- a/tests/svg/supported/circle.ivg
+++ b/tests/svg/supported/circle.ivg
@@ -1,0 +1,10 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	pen black
+	fill red
+	ellipse 50,50,40
+]
+

--- a/tests/svg/supported/color-names.ivg
+++ b/tests/svg/supported/color-names.ivg
@@ -1,0 +1,13 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	fill #add8e6
+	rect 10,10,30,30
+]
+context [
+	fill #006400
+	ellipse 70,70,20
+]
+

--- a/tests/svg/supported/defs-use.ivg
+++ b/tests/svg/supported/defs-use.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	fill #ffc0cb
+	rect 10,10,80,80
+]
+

--- a/tests/svg/supported/ellipse.ivg
+++ b/tests/svg/supported/ellipse.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,120,80
+fill black
+pen miter-limit:4
+context [
+	fill #00ff00
+	ellipse 60,40,50,30
+]
+

--- a/tests/svg/supported/gradient-radial.ivg
+++ b/tests/svg/supported/gradient-radial.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	fill gradient:[radial 0.5,0.5,0.5 stops:[0,white,0.5,blue,1,black]] relative:yes
+	rect 10,10,80,80
+]
+

--- a/tests/svg/supported/gradient-stops.ivg
+++ b/tests/svg/supported/gradient-stops.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	fill gradient:[linear 0,0,1,0 stops:[0,red,0.25,yellow,0.5,green,0.75,#00ffff,1,blue]] relative:yes
+	rect 10,10,80,80
+]
+

--- a/tests/svg/supported/gradient-transform.ivg
+++ b/tests/svg/supported/gradient-transform.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	fill gradient:[linear 0,0,0,100 stops:[0,red,0.5,#ffd700,1,blue]] transform:[rotate 45 anchor:50,50; scale 1.5]
+	rect 10,10,80,80
+]
+

--- a/tests/svg/supported/gradient.ivg
+++ b/tests/svg/supported/gradient.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	fill gradient:[linear 0,0,1,0 from:red to:blue] relative:yes
+	rect 10,10,80,80
+]
+

--- a/tests/svg/supported/group.ivg
+++ b/tests/svg/supported/group.ivg
@@ -1,0 +1,11 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	pen black
+	fill green
+	rect 10,10,30,30
+	ellipse 70,70,20
+]
+

--- a/tests/svg/supported/line.ivg
+++ b/tests/svg/supported/line.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	pen purple
+	path svg:[M10,10L90,90]
+]
+

--- a/tests/svg/supported/matrix.ivg
+++ b/tests/svg/supported/matrix.ivg
@@ -1,0 +1,10 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	matrix 0.5,0,0,0.5,20,20
+	fill purple
+	rect 10,10,40,40
+]
+

--- a/tests/svg/supported/multi-path.ivg
+++ b/tests/svg/supported/multi-path.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,120,60
+fill black
+pen miter-limit:4
+context [
+	pen black
+	path svg:[M10 10 H110 M10 30 H110 M10 50 H110]
+]
+

--- a/tests/svg/supported/opacity.ivg
+++ b/tests/svg/supported/opacity.ivg
@@ -1,0 +1,30 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,120,60
+fill black
+pen miter-limit:4
+context [
+	pen opacity:0.5
+	fill opacity:0.5
+	context [
+		fill red
+		rect 0,0,40,60
+	]
+	context [
+		fill green opacity:0.25
+		rect 40,0,40,60
+	]
+	context [
+		pen blue width:10 opacity:0.3
+		fill none
+		rect 80,0,40,60
+	]
+]
+context [
+	fill rgb(1,0,0) opacity:0.5
+	ellipse 20,30,10
+]
+context [
+	fill rgb(0,1,0) opacity:0.25
+	ellipse 60,30,10
+]
+

--- a/tests/svg/supported/path.ivg
+++ b/tests/svg/supported/path.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	fill yellow
+	path svg:[M10 10 L90 10 L90 90 Z]
+]
+

--- a/tests/svg/supported/percentage.ivg
+++ b/tests/svg/supported/percentage.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	fill green
+	rect 10,10,80,80
+]
+

--- a/tests/svg/supported/polygon.ivg
+++ b/tests/svg/supported/polygon.ivg
@@ -1,0 +1,9 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	fill #ffa500
+	path svg:[M50,10L90,90L10,90Z]
+]
+

--- a/tests/svg/supported/polyline.ivg
+++ b/tests/svg/supported/polyline.ivg
@@ -1,0 +1,10 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	pen black
+	fill none
+	path svg:[M10,10L90,10L90,90]
+]
+

--- a/tests/svg/supported/rect.ivg
+++ b/tests/svg/supported/rect.ivg
@@ -1,0 +1,10 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	pen blue
+	fill none
+	rect 10,10,80,80
+]
+

--- a/tests/svg/supported/skew.ivg
+++ b/tests/svg/supported/skew.ivg
@@ -1,0 +1,15 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	shear 0.5773502691896257,0
+	fill green
+	rect 10,10,30,60
+]
+context [
+	shear 0,0.5773502691896257
+	fill blue
+	rect 60,10,30,60
+]
+

--- a/tests/svg/supported/stroke-fill.ivg
+++ b/tests/svg/supported/stroke-fill.ivg
@@ -1,0 +1,10 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	pen black width:2
+	fill none
+	path svg:[M10 90 Q50 10 90 90]
+]
+

--- a/tests/svg/supported/text-stroke.ivg
+++ b/tests/svg/supported/text-stroke.ivg
@@ -1,0 +1,7 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,120,50
+fill black
+pen miter-limit:4
+font serif size:30 color:yellow outline:[black width:2]
+TEXT at:60,35 anchor:center "Hi"
+

--- a/tests/svg/supported/text.ivg
+++ b/tests/svg/supported/text.ivg
@@ -1,0 +1,7 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,40
+fill black
+pen miter-limit:4
+font serif size:20 color:blue
+TEXT at:50,25 anchor:center "Hi"
+

--- a/tests/svg/supported/transform.ivg
+++ b/tests/svg/supported/transform.ivg
@@ -1,0 +1,12 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,100,100
+fill black
+pen miter-limit:4
+context [
+	offset 10,5
+	scale 0.5,0.75
+	rotate 45 anchor:50,50
+	fill red
+	rect 10,10,80,80
+]
+

--- a/tests/svg/supported/units.ivg
+++ b/tests/svg/supported/units.ivg
@@ -1,0 +1,25 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,96,96
+fill black
+pen miter-limit:4
+context [
+	fill red
+	rect 0,0,18.897637795275593,18.897637795275593
+]
+context [
+	fill green
+	rect 18.897637795275593,0,19.200000000000003,19.200000000000003
+]
+context [
+	fill blue
+	rect 37.795275590551185,0,24,24
+]
+context [
+	fill yellow
+	rect 56.69291338582678,0,16,16
+]
+context [
+	fill purple
+	rect 75.59055118110237,0,18.89763779527559,18.89763779527559
+]
+

--- a/tests/svg/supported/viewbox.ivg
+++ b/tests/svg/supported/viewbox.ivg
@@ -1,0 +1,10 @@
+format IVG-1 requires:IMPD-1
+bounds 0,0,200,100
+fill black
+pen miter-limit:4
+scale 2
+context [
+	fill #ff00ff
+	rect 0,0,100,50
+]
+

--- a/tools/buildAndTest.cmd
+++ b/tools/buildAndTest.cmd
@@ -42,6 +42,7 @@ CALL .\tools\BuildCpp.cmd %1 %2 .\output\IVG2PNG "-DNUXPIXELS_SIMD=%simd%" /I"."
 ECHO Testing...
 CD tests
 CALL ..\tools\testIVG.cmd ..\output\IVG2PNG || GOTO error
+CALL ..\tools\testSVG.cmd || GOTO error
 
 GOTO :eof
 

--- a/tools/buildAndTest.sh
+++ b/tools/buildAndTest.sh
@@ -35,6 +35,7 @@ cd ..
 
 echo Testing...
 cd tests
-../tools/testIVG.sh ../output/IVG2PNG
+bash ../tools/testIVG.sh ../output/IVG2PNG
+bash ../tools/testSVG.sh
 cd ..
 exit 0

--- a/tools/testSVG.cmd
+++ b/tools/testSVG.cmd
@@ -1,0 +1,40 @@
+@ECHO OFF
+SETLOCAL ENABLEEXTENSIONS
+CD /D "%~dp0\..\tests\svg"
+
+IF "%~1"=="" (
+	SET exe=..\..\output\IVG2PNG
+) ELSE (
+	SET exe=%~1
+)
+SET fonts=..\..\fonts
+
+SET tempDir=%TEMP%\temp%RANDOM%
+ECHO Using temporary dir: %tempDir%
+MKDIR %tempDir%
+
+FOR %%n IN (
+	circle rect ellipse line path group color-names stroke-fill viewbox multi-path polygon polyline units percentage transform skew matrix gradient gradient-stops gradient-radial gradient-transform defs-use opacity text text-stroke
+) DO (
+	ECHO Testing %%n
+	node ..\..\tools\svg2ivg\svg2ivg.js "supported/%%n.svg" 500,500 > "%tempDir%\%%n.tmp" || GOTO error
+	more +1 "%tempDir%\%%n.tmp" > "%tempDir%\%%n.ivg"
+	DEL "%tempDir%\%%n.tmp"
+	fc "%tempDir%\%%n.ivg" "supported\%%n.ivg" || GOTO error
+	IF EXIST "supported\%%n.png" (
+		%exe% --fonts %fonts% --background white "%tempDir%\%%n.ivg" "%tempDir%\%%n.png" || GOTO error
+	)
+	ECHO.
+	ECHO.
+)
+ECHO.
+ECHO ALL GOOD!!
+ECHO.
+DEL /q "%tempDir%\*" >NUL 2>NUL
+RMDIR "%tempDir%"
+EXIT /b 0
+:error
+ECHO Error %ERRORLEVEL%
+DEL /q "%tempDir%\*" >NUL 2>NUL
+RMDIR "%tempDir%"
+EXIT /b %ERRORLEVEL%

--- a/tools/testSVG.sh
+++ b/tools/testSVG.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"/../tests/svg
+
+EXE=../../output/IVG2PNG
+FONTS=../../fonts
+if [ $# -gt 0 ]; then
+	EXE=$1
+fi
+TMP=$(mktemp -d)
+
+echo Using temporary dir: "$TMP"
+
+for NAME in circle rect ellipse line path group color-names stroke-fill viewbox multi-path polygon polyline units \
+		percentage transform skew matrix gradient gradient-stops gradient-radial gradient-transform defs-use opacity \
+		text text-stroke; do
+echo Testing "$NAME"
+node ../../tools/svg2ivg/svg2ivg.js "supported/$NAME.svg" 500,500 | tail -n +2 > "$TMP/$NAME.ivg"
+cmp "$TMP/$NAME.ivg" "supported/$NAME.ivg"
+if [ -f "supported/$NAME.png" ]; then
+$EXE --fonts "$FONTS" --background white "$TMP/$NAME.ivg" "$TMP/$NAME.png"
+fi
+echo
+echo
+done
+
+echo
+echo ALL GOOD!!
+echo
+
+rm -rf "$TMP"


### PR DESCRIPTION
## Summary
- run new svg conversion regression tests during build
- add baseline IVGs for sample SVG files
- loop `testSVG.sh` through SVG sources and invoke it via `bash`

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_689f019430b483328f279578e9977c2d