### PR TITLE
docs: expand SVG roadmap

### DIFF
--- a/docs/SVG Roadmap.md
+++ b/docs/SVG Roadmap.md
@@ -72,5 +72,6 @@ IVG only references external images via `IMAGE`; it cannot embed raster data. `s
 convert SVG `<image>` tags that use data URIs or inline content.
 
 ### Stroke Dash Arrays
-IVG lacks dashed stroke support, so `stroke-dasharray` attributes cannot be represented in the output.
+IVG supports only a single dash-gap pair, so `stroke-dasharray` lists with more than two values
+cannot be represented in the output.
 

--- a/docs/SVG Roadmap.md
+++ b/docs/SVG Roadmap.md
@@ -4,6 +4,28 @@ This document outlines a path for expanding `svg2ivg.js` to handle more of the S
 Each subsection describes the missing capability, implementation notes, and sample tests from
 `externals/resvgTests`.
 
+## Feature Rankings
+
+The lists below prioritize upcoming tasks for `svg2ivg.js`.
+
+### Importance (highest first)
+1. CSS Styles and Classes
+2. Additional Unit Types
+3. `currentColor` and `inherit`
+4. `image`
+5. Marker Elements
+6. Stroke Dash Arrays
+7. `clipPathUnits="objectBoundingBox"`
+
+### Difficulty (easiest first)
+1. Stroke Dash Arrays
+2. Additional Unit Types
+3. `currentColor` and `inherit`
+4. `image`
+5. `clipPathUnits="objectBoundingBox"`
+6. Marker Elements
+7. CSS Styles and Classes
+
 ## Text and Images
 
 ### `image`

--- a/docs/SVG Roadmap.md
+++ b/docs/SVG Roadmap.md
@@ -1,10 +1,8 @@
 # SVG Feature Roadmap
 
 This document outlines a path for expanding `svg2ivg.js` to handle more of the SVG files under `tests/svg`.
-Each subsection describes the missing capability and proposes implementation steps.
-
-## Geometry Elements
-
+Each subsection describes the missing capability, implementation notes, and sample tests from
+`externals/resvgTests`.
 
 ## Text and Images
 
@@ -13,8 +11,54 @@ Each subsection describes the missing capability and proposes implementation ste
 2. Create an IVG image command that embeds raster data with `width` and `height` scaling.
 3. Handle positioning attributes (`x`, `y`) and clipping to the viewport.
 
-### Gradients
-1. Parse `<linearGradient>` and `<radialGradient>` definitions, recording their stops and coordinates.
-2. When a `fill` or `stroke` uses `url(#id)`, look up the gradient and emit the corresponding IVG gradient commands.
-3. Handle gradient units, spread methods, and transformation attributes.
+## Styling and Paint
+
+### Marker Elements
+1. Parse `<marker>` definitions and apply `marker-start`, `marker-mid`, and `marker-end` attributes.
+2. Honor `markerUnits`, `viewBox`, and `orient`.
+
+	Sample: `externals/resvgTests/painting/marker/marker-on-line.svg`
+
+### Stroke Dash Arrays
+1. Allow `parseDashArray` to accept any number of dash segments.
+2. Emit all segments in the IVG stroke command.
+
+	Sample: `externals/resvgTests/painting/stroke-dasharray/comma-ws-separator.svg`
+
+### CSS Styles and Classes
+1. Parse `<style>` elements and build a style map.
+2. Merge rules referenced by `class` attributes before conversion.
+
+	Sample: `externals/resvgTests/structure/style/class-selector.svg`
+
+## Units and Colors
+
+### Additional Unit Types
+1. Support `em`, `rem`, `vh`, `vw`, and `ex` in `convertUnits`.
+
+	Samples:
+	- `externals/resvgTests/shapes/rect/em-values.svg`
+	- `externals/resvgTests/shapes/rect/rem-values.svg`
+	- `externals/resvgTests/shapes/rect/vw-and-vh-values.svg`
+
+### `currentColor` and `inherit`
+1. Resolve `currentColor` and `inherit` in `convertPaint` based on computed color.
+
+	Samples:
+	- `externals/resvgTests/painting/fill/currentColor.svg`
+	- `externals/resvgTests/painting/color/inherit.svg`
+
+## Clipping
+
+### `clipPathUnits="objectBoundingBox"`
+1. Compute bounding boxes for geometry before applying `clip-path`.
+2. Scale and offset clip-path contents when `clipPathUnits="objectBoundingBox"` is used.
+
+	Sample: `externals/resvgTests/masking/clipPath/clip-path-with-transform.svg`
+
+## Out of Scope
+
+### Filter Effects
+IVG has no filter command today, so `<filter>` elements such as `feGaussianBlur` or `feColorMatrix` cannot be
+supported until the IVG format adds filter instructions.
 

--- a/docs/SVG Roadmap.md
+++ b/docs/SVG Roadmap.md
@@ -12,26 +12,15 @@ The lists below prioritize upcoming tasks for `svg2ivg.js`.
 1. CSS Styles and Classes
 2. Additional Unit Types
 3. `currentColor` and `inherit`
-4. `image`
-5. Marker Elements
-6. Stroke Dash Arrays
-7. `clipPathUnits="objectBoundingBox"`
+4. Marker Elements
+5. `clipPathUnits="objectBoundingBox"`
 
 ### Difficulty (easiest first)
-1. Stroke Dash Arrays
-2. Additional Unit Types
-3. `currentColor` and `inherit`
-4. `image`
-5. `clipPathUnits="objectBoundingBox"`
-6. Marker Elements
-7. CSS Styles and Classes
-
-## Text and Images
-
-### `image`
-1. Decode `href` data URIs or external references.
-2. Create an IVG image command that embeds raster data with `width` and `height` scaling.
-3. Handle positioning attributes (`x`, `y`) and clipping to the viewport.
+1. Additional Unit Types
+2. `currentColor` and `inherit`
+3. `clipPathUnits="objectBoundingBox"`
+4. Marker Elements
+5. CSS Styles and Classes
 
 ## Styling and Paint
 
@@ -39,36 +28,30 @@ The lists below prioritize upcoming tasks for `svg2ivg.js`.
 1. Parse `<marker>` definitions and apply `marker-start`, `marker-mid`, and `marker-end` attributes.
 2. Honor `markerUnits`, `viewBox`, and `orient`.
 
-	Sample: `externals/resvgTests/painting/marker/marker-on-line.svg`
-
-### Stroke Dash Arrays
-1. Allow `parseDashArray` to accept any number of dash segments.
-2. Emit all segments in the IVG stroke command.
-
-	Sample: `externals/resvgTests/painting/stroke-dasharray/comma-ws-separator.svg`
+Sample: `externals/resvgTests/painting/marker/marker-on-line.svg`
 
 ### CSS Styles and Classes
 1. Parse `<style>` elements and build a style map.
 2. Merge rules referenced by `class` attributes before conversion.
 
-	Sample: `externals/resvgTests/structure/style/class-selector.svg`
+Sample: `externals/resvgTests/structure/style/class-selector.svg`
 
 ## Units and Colors
 
 ### Additional Unit Types
 1. Support `em`, `rem`, `vh`, `vw`, and `ex` in `convertUnits`.
 
-	Samples:
-	- `externals/resvgTests/shapes/rect/em-values.svg`
-	- `externals/resvgTests/shapes/rect/rem-values.svg`
-	- `externals/resvgTests/shapes/rect/vw-and-vh-values.svg`
+Samples:
+- `externals/resvgTests/shapes/rect/em-values.svg`
+- `externals/resvgTests/shapes/rect/rem-values.svg`
+- `externals/resvgTests/shapes/rect/vw-and-vh-values.svg`
 
 ### `currentColor` and `inherit`
 1. Resolve `currentColor` and `inherit` in `convertPaint` based on computed color.
 
-	Samples:
-	- `externals/resvgTests/painting/fill/currentColor.svg`
-	- `externals/resvgTests/painting/color/inherit.svg`
+Samples:
+- `externals/resvgTests/painting/fill/currentColor.svg`
+- `externals/resvgTests/painting/color/inherit.svg`
 
 ## Clipping
 
@@ -76,11 +59,18 @@ The lists below prioritize upcoming tasks for `svg2ivg.js`.
 1. Compute bounding boxes for geometry before applying `clip-path`.
 2. Scale and offset clip-path contents when `clipPathUnits="objectBoundingBox"` is used.
 
-	Sample: `externals/resvgTests/masking/clipPath/clip-path-with-transform.svg`
+Sample: `externals/resvgTests/masking/clipPath/clip-path-with-transform.svg`
 
 ## Out of Scope
 
 ### Filter Effects
 IVG has no filter command today, so `<filter>` elements such as `feGaussianBlur` or `feColorMatrix` cannot be
 supported until the IVG format adds filter instructions.
+
+### `<image>` Elements
+IVG only references external images via `IMAGE`; it cannot embed raster data. `svg2ivg.js` therefore cannot
+convert SVG `<image>` tags that use data URIs or inline content.
+
+### Stroke Dash Arrays
+IVG lacks dashed stroke support, so `stroke-dasharray` attributes cannot be represented in the output.
 


### PR DESCRIPTION
## Summary
- outline support for markers, dash arrays, CSS styles, additional units, color keywords, and clipPath objectBoundingBox
- reference resvg test cases for each planned feature
- note lack of filter support in IVG as an out-of-scope item

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_689f2c18a2648332b49c404884590319