### PR TITLE
Fix clipPathUnits test on Windows

### DIFF
--- a/tools/testSVG.cmd
+++ b/tools/testSVG.cmd
@@ -14,15 +14,15 @@ ECHO Using temporary dir: %tempDir%
 MKDIR %tempDir%
 
 FOR %%n IN (
-	circle rect ellipse line path group color-names stroke-fill viewbox multi-path polygon polyline units percentage transform skew matrix gradient gradient-stops gradient-radial gradient-transform defs-use opacity text text-stroke resvg_tests_shapes_rect_em-values resvg_tests_shapes_rect_vw-and-vh-values resvg_tests_painting_color_inherit resvg_tests_masking_clipPath_clipPathUnits=objectBoundingBox resvg_tests_painting_marker_marker-on-line
+       circle rect ellipse line path group color-names stroke-fill viewbox multi-path polygon polyline units percentage transform skew matrix gradient gradient-stops gradient-radial gradient-transform defs-use opacity text text-stroke resvg_tests_shapes_rect_em-values resvg_tests_shapes_rect_vw-and-vh-values resvg_tests_painting_color_inherit "resvg_tests_masking_clipPath_clipPathUnits=objectBoundingBox" resvg_tests_painting_marker_marker-on-line
 ) DO (
-	ECHO Testing %%n
-	node ..\..\tools\svg2ivg\svg2ivg.js "supported/%%n.svg" 500,500 > "%tempDir%\%%n.tmp" || GOTO error
-	more +1 "%tempDir%\%%n.tmp" > "%tempDir%\%%n.ivg"
-	DEL "%tempDir%\%%n.tmp"
-	fc "%tempDir%\%%n.ivg" "supported\%%n.ivg" || GOTO error
-	IF EXIST "supported\%%n.png" (
-		%exe% --fonts %fonts% --background white "%tempDir%\%%n.ivg" "%tempDir%\%%n.png" || GOTO error
+       ECHO Testing %%~n
+       node ..\..\tools\svg2ivg\svg2ivg.js "supported/%%~n.svg" 500,500 > "%tempDir%\%%~n.tmp" || GOTO error
+       more +1 "%tempDir%\%%~n.tmp" > "%tempDir%\%%~n.ivg"
+       DEL "%tempDir%\%%~n.tmp"
+       fc "%tempDir%\%%~n.ivg" "supported\%%~n.ivg" || GOTO error
+       IF EXIST "supported\%%~n.png" (
+               %exe% --fonts %fonts% --background white "%tempDir%\%%~n.ivg" "%tempDir%\%%~n.png" || GOTO error
 	)
 	ECHO.
 	ECHO.


### PR DESCRIPTION
## Summary
- quote `clipPathUnits` SVG test case in Windows runner to avoid environment variable expansion
- handle quoted test names with `%%~n` so the file path resolves correctly

## Testing
- `timeout 180 bash ./tools/testSVG.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a1c0a838f08332858c79afc45f6ec8