### PR TITLE
Add resvg path shape SVG tests

### DIFF
--- a/tests/svg/supported/resvg_tests_shapes_path_M-C.svg
+++ b/tests/svg/supported/resvg_tests_shapes_path_M-C.svg
@@ -1,0 +1,9 @@
+<svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <title>M C</title>
+
+    <path id="path1" d="M 30 40 C 16 137 171 45 180 155"
+          fill="none" stroke="green" stroke-width="5"/>
+
+    <!-- image frame -->
+    <rect id="frame" x="1" y="1" width="198" height="198" fill="none" stroke="black"/>
+</svg>

--- a/tests/svg/supported/resvg_tests_shapes_path_M-L-L-Z.svg
+++ b/tests/svg/supported/resvg_tests_shapes_path_M-L-L-Z.svg
@@ -1,0 +1,8 @@
+<svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <title>M L L z</title>
+
+    <path id="path1" d="M 30 40 L 100 150 L 160 110 z" fill="none" stroke="green" stroke-width="5"/>
+
+    <!-- image frame -->
+    <rect id="frame" x="1" y="1" width="198" height="198" fill="none" stroke="black"/>
+</svg>

--- a/tests/svg/supported/resvg_tests_shapes_path_M-Q-T.svg
+++ b/tests/svg/supported/resvg_tests_shapes_path_M-Q-T.svg
@@ -1,0 +1,9 @@
+<svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <title>M Q T</title>
+
+    <path id="path1" d="M 30 40 Q 171 45 100 90 T 160 180"
+          fill="none" stroke="green" stroke-width="5"/>
+
+    <!-- image frame -->
+    <rect id="frame" x="1" y="1" width="198" height="198" fill="none" stroke="black"/>
+</svg>


### PR DESCRIPTION
## Summary
- add SVGs for cubic, quadratic, and line path shapes from resvg tests

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a2f1375a8c8332a6f5b9bc96f52e6b