### PR TITLE
Document PolygonMask coverageDelta buffer

### DIFF
--- a/externals/NuX/NuXPixels.h
+++ b/externals/NuX/NuXPixels.h
@@ -971,7 +971,7 @@ class PolygonMask : public Renderer<Mask8> {
 	protected:	mutable int row;
 	protected:	mutable int engagedStart;
 	protected:	mutable int engagedEnd;
-	protected:	mutable std::vector<Int32> coverageDelta;
+	protected:	mutable std::vector<Int32> coverageDelta;	/// per-column coverage deltas integrated each row
 	protected:	mutable std::vector<Segment*> segsVertically;
 	protected:	mutable std::vector<Segment*> segsHorizontally;
 #if !defined(NDEBUG)


### PR DESCRIPTION
## Summary
- Document coverageDelta's role in PolygonMask
- Clarify per-column delta buffer in NuXPixels docs

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a3344faee08332a82f7b56280e21a5