### PR TITLE
Clarify NuXPixels docs and svg2ivg usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,23 @@ instructions when available.
 
 ## Helper Scripts
 
-- `build.sh` / `build.cmd` – build both the **beta** and **release** targets and run all tests  
+- `build.sh` / `build.cmd` – build both the **beta** and **release** targets and run all tests
 - `tools/updateIVGTests.sh` / `.cmd` – regenerate golden PNGs from all `.ivg` test files
 - `tools/updateDocumentation.sh` – rebuild HTML documentation using Pandoc and PikaScript
   (Mac / Linux only)
+
+## svg2ivg
+
+`svg2ivg` converts a subset of SVG into IVG's ImpD language. The Node.js script
+resides at `tools/svg2ivg/svg2ivg.js` and is invoked as:
+
+```
+node tools/svg2ivg/svg2ivg.js input.svg [output.ivg] [defaultWidth,defaultHeight]
+```
+
+Omitting `output.ivg` prints the converted ImpD to stdout. See
+[docs/SVG Support.md](docs/SVG%20Support.md) for supported features and
+`tests/svg` for sample inputs.
 
 ## IVGFiddle
 

--- a/docs/NuXPixels Documentation.md
+++ b/docs/NuXPixels Documentation.md
@@ -22,7 +22,9 @@
 - [Examples and Recipes](#examples-and-recipes)
 ## Intro
 
-_NuXPixels_ is a small C++ library for 2D graphics rendering. It is designed to be self contained with no operating system dependencies and focuses on a minimal API with high quality anti‑aliasing. The renderer operates entirely in memory.
+_NuXPixels_ is a small C++ library for 2D graphics rendering. It is designed to be self contained
+ with no operating system dependencies and focuses on a minimal API with high quality
+ anti‑aliasing. The renderer operates entirely in memory.
 
 ## Quickstart
 
@@ -58,10 +60,16 @@ Compile with `g++ example.cpp -std=c++17` (or a similar C++17 compiler command).
 ## Core Data Types
 
 ### Points and Rectangles
-`NuXPixels` defines generic `Point<T>` and `Rect<T>` templates for integer and floating point coordinates. Convenience typedefs such as `IntPoint`, `IntRect` and `Vertex` (a double precision point) are available for common use.
 
-`Rect<T>` uses half‑open bounds `[left, left+width) × [top, top+height)` and expects non‑negative `width` and `height`. When rectangles only touch at an edge the intersection is empty. `IntRect` stores 31‑bit signed coordinates (`FULL_RECT` spans ±0x40000000) while floating variants rely on `double`. `Rect<T>` provides helpers like `offset`, `calcUnion` and `calcIntersection` to manipulate regions.
-These operations simplify clipping logic:
+`NuXPixels` defines generic `Point<T>` and `Rect<T>` templates for integer and floating point
+coordinates. Convenience typedefs such as `IntPoint`, `IntRect` and `Vertex` (a double precision
+point) are available for common use.
+
+`Rect<T>` uses half‑open bounds `[left, left+width) × [top, top+height)` and expects non‑negative
+`width` and `height`. When rectangles only touch at an edge the intersection is empty. `IntRect`
+stores 31‑bit signed coordinates (`FULL_RECT` spans ±0x40000000) while floating variants rely on
+`double`. `Rect<T>` provides helpers like `offset`, `calcUnion` and `calcIntersection` to
+manipulate regions. These operations simplify clipping logic:
 
 ```cpp
 IntRect a(0, 0, 50, 50);
@@ -70,10 +78,18 @@ IntRect clipped = a.calcIntersection(b);
 ```
 
 ### Pixel Formats
-The library ships with a few pixel formats. `ARGB32` stores premultiplied 8‑bit channels in `0xAARRGGBB` order. A lightweight `Mask8` type carries 8‑bit coverage when rendering masks.
+
+The library ships with a few pixel formats. `ARGB32` stores premultiplied 8‑bit channels in
+`0xAARRGGBB` order. A lightweight `Mask8` type carries 8‑bit coverage when rendering masks.
 
 ### Color Math
-Pixels are interpreted as sRGB and all arithmetic happens in that gamma space; no linear conversion is performed. Blending follows the conventional `dst * (255 - src.a) / 255 + src` equation on premultiplied channels, where `src.a` is the source alpha (0–255). Intermediate arithmetic uses integers with truncation, so channel multiplications round toward zero. `ARGB32` provides utilities such as `add`, `multiply` and `interpolate` for pixel arithmetic. A color can be constructed from floats and then modulated:
+
+Pixels are interpreted as sRGB and all arithmetic happens in that gamma space; no linear conversion
+is performed. Blending follows the conventional `dst * (255 - src.a) / 255 + src` equation on
+premultiplied channels, where `src.a` is the source alpha (0–255). Intermediate arithmetic uses
+integers with truncation, so channel multiplications round toward zero. `ARGB32` provides utilities
+such as `add`, `multiply` and `interpolate` for pixel arithmetic. A color can be constructed from
+floats and then modulated:
 
 ```cpp
 ARGB32::Pixel p = ARGB32::fromFloatRGB(1.0, 0.0, 0.0, 0.5); // 50% red
@@ -82,7 +98,9 @@ ARGB32::Pixel dark = ARGB32::multiply(p, 128);               // scale alpha & rg
 ```
 
 ### AffineTransformations
-`AffineTransformation` represents 2×3 matrices for translation, scaling, rotation and shearing. Transformations can be composed with the `transform()` function and applied to vertices or paths.
+
+`AffineTransformation` represents 2×3 matrices for translation, scaling, rotation and shearing.
+Transformations can be composed with the `transform()` function and applied to vertices or paths.
 
 Chained calls build complex transforms in a readable manner:
 
@@ -93,17 +111,21 @@ AffineTransformation t = AffineTransformation()
 	.rotate(0.25 * M_PI);
 ```
 
-Transforms are pre‑multiplied (points are column vectors), so calls execute left‑to‑right: `translate().scale().rotate()` means translate, then scale, then rotate in object space. Angles are specified in radians.
+Transforms are pre‑multiplied (points are column vectors), so calls execute left‑to‑right:
+`translate().scale().rotate()` means translate, then scale, then rotate in object space. Angles are
+specified in radians.
 
 ## Rendering Pipeline
 
 ### Raster and Renderer
-All drawing is expressed through `Renderer` templates that generate spans of
-pixel data. A span models a contiguous horizontal run. When marked *solid* the
-span stores one pixel value repeated for the entire run; otherwise it carries an
-array of per-pixel values so coverage or color may vary across the span. Each
-span also flags opaque or transparent runs to enable culling. Spans longer than
-`MAX_RENDER_LENGTH` are split automatically. `Raster<T>` collects the result in a client supplied buffer while `SelfContainedRaster<T>` manages its own memory. A typical pipeline blends color data from `Renderer<ARGB32>` through coverage masks produced by `Renderer<Mask8>` sources:
+
+All drawing is expressed through `Renderer` templates that generate spans of pixel data. A span
+models a contiguous horizontal run. When marked *solid* the span stores one pixel value repeated
+for the entire run; otherwise it carries an array of per-pixel values so coverage or color may vary
+across the span. Each span also flags opaque or transparent runs to enable culling. Spans longer
+than `MAX_RENDER_LENGTH` are split automatically. `Raster<T>` collects the result in a client
+supplied buffer while `SelfContainedRaster<T>` manages its own memory. A typical pipeline blends
+color data from `Renderer<ARGB32>` through coverage masks produced by `Renderer<Mask8>` sources:
 
 ```cpp
 ARGB32::Pixel pixels[1024 * 1024];
@@ -115,28 +137,27 @@ view |= Solid<ARGB32>(0xFFFF0000) * mask;
 ```
 
 ### PolygonMask
-`PolygonMask` is the workhorse renderer for filling paths. Given a vector `Path`
-and an optional fill rule, it converts the geometry into a scanline coverage mask
-(`Renderer<Mask8>`). Paint sources such as solid colors or gradients are then
-blended through this mask onto the destination raster. Scanlines are processed
-sequentially from top to bottom. Coverage values range 0–255 with 8‑bit subpixel
-precision, and both even‑odd and non‑zero winding rules are supported. The
-constructor accepts an optional clip rectangle (defaulting to `FULL_RECT`), which
-is clamped to the maximum coordinate range and applied before rasterization.
+
+`PolygonMask` is the workhorse renderer for filling paths. Given a vector `Path` and an optional
+fill rule, it converts the geometry into a scanline coverage mask(`Renderer<Mask8>`). Paint sources
+such as solid colors or gradients are then blended through this mask onto the destination raster.
+Scanlines are processed sequentially from top to bottom. Coverage values range 0–255 with 8‑bit
+subpixel precision, and both even‑odd and non‑zero winding rules are supported. The constructor
+accepts an optional clip rectangle (defaulting to `FULL_RECT`), which is clamped to the maximum
+coordinate range and applied before rasterization.
 
 Further details on the algorithm, design trade‑offs and pseudo‑code are available in `PolygonMask Rasterizer.md`.
 
 ### Gradients
-A `Gradient` lookup table produces color values for linear or radial fills.
-`LinearAscend` and `RadialAscend` generate a 0–255 coverage ramp that can index
-into a gradient: `gradient[LinearAscend(x0, y0, x1, y1)]` or
-`gradient[RadialAscend(cx, cy, rx, ry)]` yield a color renderer. The library also
-provides a `GammaTable` for simple tone adjustments.
 
-Stops must be supplied in ascending order and are interpolated in premultiplied
-space. The ramp spans indices `0–255` inclusive and clamps at the ends; gradients
-neither repeat nor reflect. Large color steps may band since no dithering is
-applied.
+A `Gradient` lookup table produces color values for linear or radial fills. `LinearAscend` and
+`RadialAscend` generate a 0–255 coverage ramp that can index into a gradient: `gradient
+[LinearAscend(x0, y0, x1, y1)]` or `gradient[RadialAscend(cx, cy, rx, ry)]` yield a color renderer.
+The library also provides a `GammaTable` for simple tone adjustments.
+
+Stops must be supplied in ascending order and are interpolated in premultiplied space. The ramp
+spans indices `0–255` inclusive and clamps at the ends; gradients neither repeat nor reflect. Large
+color steps may band since no dithering is applied.
 
 ```cpp
 Gradient<ARGB32>::Stop stops[] = {
@@ -151,12 +172,16 @@ Gradient<ARGB32>::Stop stops2[] = {
 {1.0, 0xFFFFFFFF}
 };
 ```
-See [Lifetime of Renderers](#lifetime-of-renderers) for notes on gradient lookups referencing their ramps.
+
+See [Lifetime of Renderers](#lifetime-of-renderers) for notes on gradient lookups referencing their
+ramps.
 
 
 ### Solid and Texture
+
 `Solid<T>` outputs a constant pixel value. `Texture<T>` samples from a raster using an affine
-transformation and optional wrapping (repeat when `wrap=true`, otherwise clamp to transparent black). Sampling uses 16.16 fixed-point coordinates with bilinear filtering.
+transformation and optional wrapping (repeat when `wrap=true`, otherwise clamp to transparent
+black). Sampling uses 16.16 fixed-point coordinates with bilinear filtering.
 
 ```cpp
 Texture<ARGB32> tex(image, true, AffineTransformation().scale(0.5));
@@ -165,36 +190,39 @@ canvas |= tex * mask; // Defaults: bilinear filter, wrap repeat
 ```
 
 ### RLERaster
-`RLERaster<T>` stores spans in run-length encoded form for reuse. It is handy for caching
-masks so that complex paths need not be rasterized repeatedly.
+
+`RLERaster<T>` stores spans in run-length encoded form for reuse. It is handy for caching masks so
+that complex paths need not be rasterized repeatedly.
 
 ```cpp
 RLERaster<Mask8> cache(area, mask);
 canvas |= Solid<ARGB32>(color) * cache;
 ```
 
-Runs encode either a solid pixel or a block of per‑pixel data. Each span stores a 16‑bit header plus optional pixel payload, preserving partial alpha. Compression ratio depends on image coherence—solid regions compress heavily while noisy images approach raw size.
+Runs encode either a solid pixel or a block of per‑pixel data. Each span stores a 16‑bit header plus
+optional pixel payload, preserving partial alpha. Compression ratio depends on image
+coherence—solid regions compress heavily while noisy images approach raw size.
 
 ## Operator Overloading
-Renderers can be combined with `*`, `+`, `|`, `+=`, `*=`, and `|=` operators.
-Each operator returns another `Renderer` that lazily requests spans from its
-inputs. An expression like `canvas |= Solid<ARGB32>(color) * mask` forms a small
-pipeline. Operator precedence follows C++ rules: `*` binds tighter than `|`. The
-`|` operator blends the right renderer over the left; it is not a bitwise OR.
+
+Renderers can be combined with `*`, `+`, `|`, `+=`, `*=`, and `|=` operators. Each operator returns
+another `Renderer` that lazily requests spans from its inputs. An expression like `canvas |=
+Solid<ARGB32>(color) * mask` forms a small pipeline. Operator precedence follows C++ rules: `*`
+binds tighter than `|`. The `|` operator blends the right renderer over the left; it is not a
+bitwise OR.
 
 ## Pull Model
-As the canvas renders, it pulls spans from the expression and each stage only
-computes what the next stage requires. Because drawing is demand driven,
-NuXPixels can optimize away work in real time. Opaque spans automatically block
-processing of any renderers beneath them since those pixels are invisible. This
-culling happens per span and keeps the renderer efficient even with many
-layers.
+
+As the canvas renders, it pulls spans from the expression and each stage only computes what the next
+stage requires. Because drawing is demand driven, NuXPixels can optimize away work in real time.
+Opaque spans automatically block processing of any renderers beneath them since those pixels are
+invisible. This culling happens per span and keeps the renderer efficient even with many layers.
 
 ## Lifetime of Renderers
-Most renderer types store references to the objects passed into their
-constructors or operators. C++ destroys temporary objects at the end of the
-statement, so a renderer built from temporaries must also be used in that same
-statement. To keep a renderer for later, create and store every component
+
+Most renderer types store references to the objects passed into their constructors or operators. C++
+destroys temporary objects at the end of the statement, so a renderer built from temporaries must
+also be used in that same statement. To keep a renderer for later, create and store every component
 separately so their lifetimes extend as needed.
 
 ```cpp
@@ -207,12 +235,12 @@ canvas |= lookup; /// `grad` and `ramp` must outlive `lookup`
 canvas |= Gradient<ARGB32>(2, stops)[LinearAscend(x0, y0, x1, y1)]; /// safe: everything is temporary
 ```
 
-This rule applies to all expressions in NuXPixels—`PolygonMask`, `Texture`,
-`Solid`, gradients and more. Either chain the full expression in a single
-statement or keep each renderer alive for as long as any derived renderer uses
-it.
+This rule applies to all expressions in NuXPixels—`PolygonMask`, `Texture`, `Solid`, gradients and
+more. Either chain the full expression in a single statement or keep each renderer alive for as
+long as any derived renderer uses it.
 
-Even types that are trivially copyable still reference external data; treat renderers as views rather than owning objects.
+Even types that are trivially copyable still reference external data; treat renderers as views
+rather than owning objects.
 
 | Renderer | References | Ownership |
 |---|---|---|
@@ -224,7 +252,13 @@ Even types that are trivially copyable still reference external data; treat rend
 | RLERaster<T> | none | owns span/pixel arrays |
 
 ## Path Construction
-`Path` records drawing commands such as `moveTo`, `lineTo`, `quadraticTo`, `cubicTo`, `arcSweep` and `close`. Convenience helpers like `addRect`, `addEllipse`, `addCircle`, `addRoundedRect` and `addStar` append common shapes. `stroke` replaces the path with its stroked outline while `dash` rewrites segments to alternate drawn and skipped portions. All operations modify the path in place but return `*this` for chaining. Paths operate in double precision and can be transformed with an `AffineTransformation` before rendering.
+
+`Path` records drawing commands such as `moveTo`, `lineTo`, `quadraticTo`, `cubicTo`, `arcSweep` and
+`close`. Convenience helpers like `addRect`, `addEllipse`, `addCircle`, `addRoundedRect` and
+`addStar` append common shapes. `stroke` replaces the path with its stroked outline while `dash`
+rewrites segments to alternate drawn and skipped portions. All operations modify the path in place
+but return `*this` for chaining. Paths operate in double precision and can be transformed with an
+`AffineTransformation` before rendering.
 
 ```cpp
 Path star;
@@ -233,19 +267,27 @@ star.stroke(3.0, Path::ROUND, Path::MITER);
 star.dash(5.0, 2.0);
 ```
 
-`stroke(width, endCaps, joints, miterLimit, curveQuality)` defaults to a miter limit of `2.0`. `EndCapStyle` may be `BUTT`, `ROUND`, or `SQUARE`; `JointStyle` is `BEVEL`, `CURVE`, or `MITER`. `dash(dashLength, gapLength, dashOffset)` alternates drawn and skipped segments starting at `dashOffset`; fractional lengths accumulate along each sub-path and the pattern resets at every `moveTo`.
+`stroke(width, endCaps, joints, miterLimit, curveQuality)` defaults to a miter limit of `2.0`.
+`EndCapStyle` may be `BUTT`, `ROUND`, or `SQUARE`; `JointStyle` is `BEVEL`, `CURVE`, or `MITER`.
+`dash(dashLength, gapLength, dashOffset)` alternates drawn and skipped segments starting at
+`dashOffset`; fractional lengths accumulate along each sub-path and the pattern resets at every
+`moveTo`.
 
 ## Limits and Safety
 
 - Maximum span length is 256 pixels (`MAX_RENDER_LENGTH`); longer runs are split automatically.
 - `IntRect` uses 31‑bit signed coordinates (`FULL_RECT`); floating types use `double` values.
-- Texture sampling outside the source repeats when `wrap=true` and returns transparent black (`0x00000000`) when `wrap=false`.
+- Texture sampling outside the source repeats when `wrap=true` and returns transparent black
+  (`0x00000000`) when `wrap=false`.
 - Renderers and rasters are not thread‑safe; use separate instances on different threads.
-- Requesting scanlines out of order forces `PolygonMask` to rewind and resort edges, which is slower than sequential rendering.
+- Requesting scanlines out of order forces `PolygonMask` to rewind and resort edges, which is slower
+  than sequential rendering.
 - `RLERaster` compresses runs; memory usage varies with image content.
 - Paths with fewer than two points or zero-length segments yield zero coverage.
 - Color and coverage calculations use 8‑bit integer arithmetic with truncation.
-- Many routines assume coordinates roughly within -32768 to 32767; exceeding that range can overflow internal 16-bit accumulators or lose precision. `IntRect` stores 31-bit signed coordinates (`FULL_RECT` spans ±0x40000000); exceeding this may overflow.
+- Many routines assume coordinates roughly within -32768 to 32767; exceeding that range can overflow
+  internal 16-bit accumulators or lose precision. `IntRect` stores 31-bit signed coordinates
+  (`FULL_RECT` spans ±0x40000000); exceeding this may overflow.
 - Functions do not guarantee `noexcept` and may fail on allocation.
 
 ## Examples and Recipes
@@ -264,11 +306,11 @@ PolygonMask mask(rect, canvas.calcBounds());
 // Multiply the coverage mask with a solid color and alpha-blend onto the canvas
 canvas |= Solid<ARGB32>(0xFFFF0000) * mask;
 ```
-Here `*` multiplies the color renderer with the `PolygonMask`, producing
-`Renderer<ARGB32>` spans masked by the polygon coverage. The resulting renderer
-is then blended onto `canvas` with `|=`. The entire expression becomes a pull
-pipeline: the canvas requests pixels, which asks the mask for coverage, which in
-turn iterates the path only for the visible spans. Similar expressions can chain
+
+Here `*` multiplies the color renderer with the `PolygonMask`, producing `Renderer<ARGB32>` spans
+masked by the polygon coverage. The resulting renderer is then blended onto `canvas` with `|=`. The
+entire expression becomes a pull pipeline: the canvas requests pixels, which asks the mask for
+coverage, which in turn iterates the path only for the visible spans. Similar expressions can chain
 gradients or multiple masks together.
 
 This program (including file output) is available as `tests/red_square.cpp`.

--- a/docs/NuXPixels Documentation.md
+++ b/docs/NuXPixels Documentation.md
@@ -13,10 +13,11 @@
   - [Gradients](#gradients)
   - [Solid and Texture](#solid-and-texture)
   - [RLERaster](#rleraster)
-  - [Operator overloading](#operator-overloading-and-pull-model)
-- [Path construction](#path-construction)
-- [Limits and Safety](#limits-and-safety)
-- [Examples](#examples)
+  - [Operator overloading](#operator-overloading)
+  - [Pull model](#pull-model)
+  - [Path construction](#path-construction)
+  - [Limits and Safety](#limits-and-safety)
+  - [Examples](#examples)
 ## Intro
 
 _NuXPixels_ is a small C++ library for 2D graphics rendering. It is designed to be self contained with no operating system dependencies and focuses on a minimal API with high quality anti‑aliasing. The renderer operates entirely in memory.
@@ -54,7 +55,7 @@ IntRect clipped = a.calcIntersection(b);
 ```
 
 ### Colors
-The library ships with a few pixel formats. `ARGB32` stores premultiplied 8‑bit channels in `0xAARRGGBB` order (little‑endian machines lay the bytes out as BB GG RR AA). Blending follows `dst + src - dst * srcA / 255`. Colors are assumed sRGB and math is performed on premultiplied channels in linear space. A lightweight `Mask8` type is used when rendering coverage masks.
+The library ships with a few pixel formats. `ARGB32` stores premultiplied 8‑bit channels in `0xAARRGGBB` order (little‑endian machines lay the bytes out as BB GG RR AA). Blending follows the conventional `dst*(255-srcA)/255 + src` equation. Colors are assumed sRGB and all computations occur on premultiplied channels in that gamma space; there is no implicit linearization. Intermediate arithmetic uses integer math with truncation, so channel multiplications are rounded toward zero. A lightweight `Mask8` type is used when rendering coverage masks.
 
 `ARGB32` also includes `multiply` and `interpolate` utilities for pixel arithmetic. A color can be constructed from floats and then modulated:
 
@@ -76,7 +77,7 @@ AffineTransformation t = AffineTransformation()
 	.rotate(0.25 * M_PI);
 ```
 
-Transforms are post‑multiplied (points are column vectors), so `translate().scale().rotate()` means rotate, then scale, then translate in object space. Angles are specified in radians.
+Transforms are pre‑multiplied (points are column vectors), so calls execute left‑to‑right: `translate().scale().rotate()` means translate, then scale, then rotate in object space. Angles are specified in radians.
 
 ## Rendering pipeline
 
@@ -84,7 +85,8 @@ Transforms are post‑multiplied (points are column vectors), so `translate().sc
 All drawing is expressed through `Renderer` templates that generate spans of
 pixel data. A span models a contiguous horizontal run. When marked *solid* the
 span stores one pixel value repeated for the entire run; otherwise it carries an
-array of per-pixel values, allowing coverage or color to vary. `Raster<T>` collects the result in a client supplied buffer while `SelfContainedRaster<T>` manages its own memory. A typical pipeline blends color data from `Renderer<ARGB32>` through coverage masks produced by `Renderer<Mask8>` sources.
+array of per-pixel values, allowing coverage or color to vary. Spans longer than
+`MAX_RENDER_LENGTH` are split automatically. `Raster<T>` collects the result in a client supplied buffer while `SelfContainedRaster<T>` manages its own memory. A typical pipeline blends color data from `Renderer<ARGB32>` through coverage masks produced by `Renderer<Mask8>` sources.
 
 ```cpp
 ARGB32::Pixel pixels[256 * 256];
@@ -119,6 +121,8 @@ into a gradient: `gradient[LinearAscend(x0, y0, x1, y1)]` or
 `gradient[RadialAscend(cx, cy, rx, ry)]` yield a color renderer. The library also
 provides a `GammaTable` for simple tone adjustments.
 
+Stops are sorted by position and interpolated in premultiplied sRGB space. The ramp spans indices `0–255` inclusive and clamps at the ends; gradients neither repeat nor reflect. Large color steps may band since no dithering is applied.
+
 ```cpp
 Gradient<ARGB32>::Stop stops[] = {
 	{0.0, 0xFF0000FF},// blue
@@ -148,12 +152,12 @@ Gradient<ARGB32>::Stop stops2[] = {
 
 ### Solid and Texture
 `Solid<T>` outputs a constant pixel value. `Texture<T>` samples from a raster using an affine
-transformation and optional wrapping.
+transformation and optional wrapping (repeat when `wrap=true`, otherwise clamp to transparent black). Sampling uses 16.16 fixed-point coordinates with bilinear filtering.
 
 ```cpp
 Texture<ARGB32> tex(image, true, AffineTransformation().scale(0.5));
 canvas |= tex * mask; // Defaults: bilinear filter, wrap repeat
-// Clamp with wrap=false; sampling happens in premultiplied space.
+// Clamp with wrap=false to sample transparent black; sampling happens in premultiplied space.
 ```
 
 ### RLERaster
@@ -167,19 +171,20 @@ canvas |= Solid<ARGB32>(color) * cache;
 
 Runs encode either a solid pixel or a block of per‑pixel data. Each span stores a 16‑bit header plus optional pixel payload, preserving partial alpha. Memory footprint is typically 20–60% of an uncompressed raster depending on image coherence.
 
-### Operator overloading and pull model
+### Operator overloading
 Renderers can be combined with `*`, `+`, `|`, `+=`, `*=`, and `|=` operators.
 Each operator returns another `Renderer` that lazily requests spans from its
 inputs. An expression like `canvas |= Solid<ARGB32>(color) * mask` forms a small
-pipeline. As the canvas renders, it pulls spans from that pipeline and each stage
-only computes what the next stage requires.
+pipeline. Operator precedence follows C++ rules: `*` binds tighter than `|`. The
+`|` operator blends the right renderer over the left; it is not a bitwise OR.
 
-Because drawing is demand driven, NuXPixels can optimize away work in real time.
-Opaque spans automatically block processing of any renderers beneath them since
-those pixels are invisible. This culling happens per span and keeps the renderer
-efficient even with many layers.
-
-Operator precedence follows C++ rules: `*` binds tighter than `|`. The `|` operator blends the right renderer over the left; it is not a bitwise OR.
+### Pull model
+As the canvas renders, it pulls spans from the expression and each stage only
+computes what the next stage requires. Because drawing is demand driven,
+NuXPixels can optimize away work in real time. Opaque spans automatically block
+processing of any renderers beneath them since those pixels are invisible. This
+culling happens per span and keeps the renderer efficient even with many
+layers.
 
 ### Lifetime of renderers
 Most renderer types store references to the objects passed into their
@@ -211,6 +216,7 @@ Even types that are trivially copyable still reference external data; treat rend
 | Texture<T> | source `Raster<T>` | no |
 | PolygonMask | `Path`, `FillRule` | no |
 | Gradient<T> | copy of stops | table |
+| Gradient<T>::Lookup | gradient, ramp | no |
 | RLERaster<T> | none | owns span/pixel arrays |
 
 ## Path construction
@@ -223,7 +229,7 @@ star.stroke(3.0, Path::ROUND, Path::MITER);
 star.dash(5.0, 2.0);
 ```
 
-`stroke(width, endCaps, joints, miterLimit, curveQuality)` defaults to a miter limit of `2.0`. `EndCapStyle` may be `BUTT`, `ROUND`, or `SQUARE`; `JointStyle` is `BEVEL`, `CURVE`, or `MITER`. `dash(dashLength, gapLength, dashOffset)` alternates drawn and skipped segments starting at `dashOffset`; fractional lengths are allowed.
+`stroke(width, endCaps, joints, miterLimit, curveQuality)` defaults to a miter limit of `2.0`. `EndCapStyle` may be `BUTT`, `ROUND`, or `SQUARE`; `JointStyle` is `BEVEL`, `CURVE`, or `MITER`. `dash(dashLength, gapLength, dashOffset)` alternates drawn and skipped segments starting at `dashOffset`; fractional lengths accumulate along each sub-path and the pattern resets at every `moveTo`.
 
 ## Examples
 
@@ -252,7 +258,7 @@ Another example uses a texture and gradient:
 
 ```cpp
 SelfContainedRaster<ARGB32> texCanvas(IntRect(0, 0, 64, 64));
-Gradient<ARGB32> grad(ARGB32::transparent(), 0xff00ff00);
+Gradient<ARGB32> grad(ARGB32::transparent(), 0xFF00FF00); // 0xAARRGGBB: green
 texCanvas |= grad[RadialAscend(32, 32, 32, 32)];
 
 Texture<ARGB32> tex(texCanvas, true);
@@ -261,10 +267,10 @@ canvas |= tex * mask;
 
 ## Limits and Safety
 
-- Maximum span length is 256 pixels (`MAX_RENDER_LENGTH`).
+- Maximum span length is 256 pixels (`MAX_RENDER_LENGTH`); longer runs are chunked automatically.
 - Coordinates are 31‑bit signed; `FULL_RECT` defines the valid range.
-- Texture sampling outside the source repeats when `wrap=true` and returns transparent pixels when `wrap=false`.
-- Renderers and rasters are not thread‑safe; do not render the same instance from multiple threads simultaneously.
+- Texture sampling outside the source repeats when `wrap=true` and returns transparent black (`0x00000000`) when `wrap=false`.
+- Renderers and rasters are not thread‑safe; rendering distinct instances on separate threads is safe, but do not share one object across threads.
 - `PolygonMask::rewind()` re‑sorts segments; cost grows with edge count (≈O(n log n)).
 - `RLERaster` memory footprint is roughly 20–60% of raw raster size.
-- Degenerate paths yield zero coverage. Extremely large coordinates or NaN/Inf values lead to undefined results. Functions do not guarantee `noexcept` and may fail on allocation.
+- Paths with fewer than two points or zero-length segments yield zero coverage. Arithmetic uses integer math with truncation; invalid transforms or extreme coordinates can overflow and produce undefined results. Functions do not guarantee `noexcept` and may fail on allocation.

--- a/tests/red_square.cpp
+++ b/tests/red_square.cpp
@@ -1,0 +1,26 @@
+#include <cstdio>
+#include <cmath>
+#include "externals/NuX/NuXPixels.h"
+using namespace NuXPixels;
+
+int main() {
+	SelfContainedRaster<ARGB32> canvas(IntRect(0, 0, 64, 64));
+	Path rect;
+	rect.addRect(IntRect(8, 8, 48, 48));
+	PolygonMask mask(rect, canvas.calcBounds());
+	canvas |= Solid<ARGB32>(0xFFFF0000) * mask; // fill red square
+
+	FILE* f = fopen("out.ppm", "wb");
+	fprintf(f, "P6\n64 64\n255\n");
+	const ARGB32::Pixel* p = canvas.getPixelPointer();
+	for(int i = 0; i < 64 * 64; ++i) {
+		unsigned char rgb[3] = {
+			static_cast<unsigned char>(p[i] >> 16),
+			static_cast<unsigned char>(p[i] >> 8),
+			static_cast<unsigned char>(p[i])
+		};
+		fwrite(rgb, 1, 3, f);
+	}
+	fclose(f);
+	return 0;
+}


### PR DESCRIPTION
## Summary
- Add quickstart snippet and document coordinate ranges, ARGB32 layout, and transform order
- Expand PolygonMask, Gradient, Texture, and RLERaster sections with sampling, winding, and memory notes
- State operator precedence, lifetime rules, stroke defaults, and repository limits

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a9df68bd98833281c618ae0675ab48