### PR TITLE
Increase build timeout to 300 seconds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
 # Repository Guidelines
 
-To run the test suite use the helper script with up to three minutes allowed for execution:
+To run the test suite use the helper script with up to five minutes allowed for execution:
 
 ```bash
-timeout 180 ./build.sh
+timeout 300 ./build.sh
 ```
 
 Always execute this command before committing changes to verify that the build and regression tests succeed.

--- a/tests/svg/README.md
+++ b/tests/svg/README.md
@@ -1,7 +1,7 @@
 # svg2ivg Test Cases
 
 ## Running the Converter
-Build PikaScript via `timeout 180 ./build.sh` from the repository root, then run the converter from its folder so `xmlMini.ppeg` can be found:
+Build PikaScript via `timeout 300 ./build.sh` from the repository root, then run the converter from its folder so `xmlMini.ppeg` can be found:
 
 ```
 cd tools/svg2ivg


### PR DESCRIPTION
## Summary
- Extend recommended build timeout window from 3 to 5 minutes
- Update svg2ivg instructions to match new 300s build timeout

## Testing
- `timeout 300 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a9fa1a485883328397e275027d7f2f