### PR TITLE
Add third-party license summary

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,11 @@
+# Third-Party Licenses
+
+The project includes third-party components in the `externals/` directory.
+
+- **NuXPixels** – BSD-2-Clause. License in [NuXPixels.cpp](externals/NuX/NuXPixels.cpp). Version: n/a.
+- **libpng 1.6.37** – libpng License. See [LICENSE](externals/libpng/LICENSE).
+- **resvg test suite** – MIT or Apache-2.0 (from the resvg project). Version: n/a.
+  License files: [LICENSE-MIT](https://github.com/RazrFalcon/resvg/blob/master/LICENSE-MIT),
+  [LICENSE-APACHE](https://github.com/RazrFalcon/resvg/blob/master/LICENSE-APACHE).
+- **zlib 1.2.11** – zlib License. See [zlib.h](externals/zlib/zlib.h).
+


### PR DESCRIPTION
## Summary
- add THIRD_PARTY_LICENSES.md with license details for external components

## Testing
- `timeout 180 ./build.sh` *(fails: command terminated early; see log for partial output)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f9f6a5ec8332af9b77daf6e06a7b