### PR TITLE
Run build script with bash in docs and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build & test
-      run: |
-        chmod +x ./build.sh               # ensure it is executable
-        ./build.sh
+      run: bash build.sh
         
   linux-gcc:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Build & test
-      run: |
-        chmod +x ./build.sh
-        ./build.sh
+      run: bash build.sh

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You will need a standard C++ compiler.
 
 ## Build & Test
 
-Run `./build.sh` (or `build.cmd` on Windows) from the repository root. This builds the renderer
+Run `bash build.sh` (or `build.cmd` on Windows) from the repository root. This builds the renderer
 tools and runs the regression tests.
 
 Both the **beta** and **release** targets are compiled with optimizations enabled. The **beta**


### PR DESCRIPTION
## Summary
- document running the build via `bash build.sh`
- invoke `bash build.sh` directly in macOS and Linux CI jobs

## Testing
- `timeout 180 bash build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a9f9ea64148332998e279b5bec9a52