### PR TITLE
Add arc edge-case IVG test

### DIFF
--- a/tests/ivg/arcEdgeCases.ivg
+++ b/tests/ivg/arcEdgeCases.ivg
@@ -1,0 +1,101 @@
+FORMAT IVG-1 requires:IMPD-1
+BOUNDS 0,0,600,1000
+
+reset
+wipe white
+fill none
+pen black width:1
+
+// #1 Radii correction (lambda scaling) - simple
+context [
+offset 10,10
+pen gray width:1
+RECT 0,0,300,200
+pen black width:1
+PATH svg:[M 0 0 A 30 10 0 0 0 200 0]
+]
+
+// #2 Radii correction with rotation
+context [
+offset 310,10
+pen gray width:1
+RECT 0,0,300,200
+pen black width:1
+PATH svg:[M 0 0 A 30 10 45 0 0 200 0]
+]
+
+// #3 acos clamp (near-straight arc)
+context [
+offset 10,210
+pen gray width:1
+RECT 0,0,300,200
+pen black width:1
+PATH svg:[M 0 0 A 100000 100000 0 0 1 1e-6 0]
+]
+
+// #4 Flag independence (four distinct solutions)
+context [
+offset 310,210
+pen gray width:1
+RECT 0,0,300,200
+pen black width:1
+PATH svg:[M 50 50 A 40 30 0 0 0 250 50]
+PATH svg:[M 50 50 A 40 30 0 0 1 250 50]
+PATH svg:[M 50 50 A 40 30 0 1 0 250 50]
+PATH svg:[M 50 50 A 40 30 0 1 1 250 50]
+]
+
+// #5 Degenerate radii -> line segment
+context [
+offset 10,410
+pen gray width:1
+RECT 0,0,300,200
+pen black width:1
+PATH svg:[M 10 10 A 0 50 0 0 1 200 10]
+]
+
+// #6 Coincident endpoints -> no arc
+context [
+offset 310,410
+pen gray width:1
+RECT 0,0,300,200
+pen black width:1
+PATH svg:[M 100 100 A 50 20 0 1 1 100 100]
+]
+
+// #7 Angle wrap/normalization (tests sweep direction)
+context [
+offset 10,610
+pen gray width:1
+RECT 0,0,300,200
+pen black width:1
+PATH svg:[M 100 100 A 60 60 0 0 1 40 100]
+PATH svg:[M 100 100 A 60 60 0 0 0 40 100]
+]
+
+// #8 Rotation sensitivity (nearly 90 deg)
+context [
+offset 310,610
+pen gray width:1
+RECT 0,0,300,200
+pen black width:1
+PATH svg:[M 0 0 A 80 20 89.9999 0 1 200 0]
+]
+
+// #9 Very small delta with moderate radii
+context [
+offset 10,810
+pen gray width:1
+RECT 0,0,300,200
+pen black width:1
+PATH svg:[M 0 0 A 50 50 0 1 1 0.001 0]
+]
+
+// #10 Ellipse with rx!=ry and rotation (export sanity)
+context [
+offset 310,810
+pen gray width:1
+RECT 0,0,300,200
+pen black width:1
+PATH svg:[M 20 20 A 100 40 30 1 0 280 180]
+]


### PR DESCRIPTION
## Summary
- add `arcEdgeCases.ivg` test covering challenging SVG arc scenarios using ASCII-only comments
- remove baseline PNG so repository remains text-only

## Testing
- `timeout 300 ./build.sh` *(fails: cmp: ./png/arcEdgeCases.png: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68aaf078417c8332b51ad3cd1004dd66