### PR TITLE
Add tests for LINE and POLYGON instructions

### DIFF
--- a/tests/ivg/linePolygonTest.ivg
+++ b/tests/ivg/linePolygonTest.ivg
@@ -1,0 +1,22 @@
+FORMAT IVG-1 requires:IMPD-1
+BOUNDS 0,0,100,100
+
+RESET
+WIPE white
+
+FILL none
+PEN red width:2
+LINE 10,10,90,90
+
+FILL green
+PEN blue width:2
+POLYGON 10,80,50,20,90,80
+
+FILL none
+PEN black width:1
+LINE 10,90,30,70,50,90,70,70,90,90
+
+FILL yellow
+PEN black width:2
+POLYGON 20,30,30,20,40,30,40,50,30,60,20,50
+


### PR DESCRIPTION
## Summary
- support LINE and POLYGON instructions via parseNumberList with validation
- add regression test covering LINE and POLYGON IVG commands
- remove binary test PNG from version control
- extend test with multi-segment LINE and multi-point POLYGON examples

## Testing
- `./output/IVG2PNG --fonts fonts tests/ivg/linePolygonTest.ivg /tmp/out.png`
- `timeout 300 ./build.sh` *(missing tests/png/linePolygonTest.png)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b8a591388332a1a3d19ba26fc1c1