### PR TITLE
build: run documentation updates with local PikaCmd

### DIFF
--- a/tools/updateDocumentation.cmd
+++ b/tools/updateDocumentation.cmd
@@ -1,18 +1,16 @@
 @ECHO OFF
 CD /D "%~dp0"
 
-where pika >NUL 2>&1
-IF ERRORLEVEL 1 (
-    ECHO PikaScript not found. Install it first.
-    GOTO error
+IF NOT EXIST ..\externals\PikaCmd\output\PikaCmd.exe (
+	CALL ..\externals\PikaCmd\build.cmd || GOTO error
 )
 where pandoc >NUL 2>&1
 IF ERRORLEVEL 1 (
-    ECHO pandoc not found. Install it first.
-    GOTO error
+	ECHO pandoc not found. Install it first.
+	GOTO error
 )
 
-pika updateDocumentationImages.pika "..\docs\IVG Documentation.md" || GOTO error
+..\externals\PikaCmd\output\PikaCmd.exe updateDocumentationImages.pika "..\docs\IVG Documentation.md" || GOTO error
 pandoc -s -o "..\docs\ImpD Documentation.html" --metadata title="ImpD Documentation" --include-in-header pandoc.css "..\docs\ImpD Documentation.md" || GOTO error
 pandoc -s -o "..\docs\IVG Documentation.html" --metadata title="IVG Documentation" --include-in-header pandoc.css "..\docs\IVG Documentation.md" || GOTO error
 

--- a/tools/updateDocumentation.sh
+++ b/tools/updateDocumentation.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -e -o pipefail -u
 cd "$(dirname "$0")"
-which -s pika || curl -fsSL https://nuedge.net/pikascript/install.sh | sh
+if [ ! -x ../externals/PikaCmd/output/PikaCmd ]; then
+	bash ../externals/PikaCmd/build.sh
+fi
 which -s pandoc || brew install pandoc
-pika updateDocumentationImages.pika "../docs/IVG Documentation.md"
+../externals/PikaCmd/output/PikaCmd updateDocumentationImages.pika "../docs/IVG Documentation.md"
 pandoc -s -o "../docs/ImpD Documentation.html" --metadata title="ImpD Documentation" --include-in-header pandoc.css "../docs/ImpD Documentation.md"
 pandoc -s -o "../docs/IVG Documentation.html" --metadata title="IVG Documentation" --include-in-header pandoc.css "../docs/IVG Documentation.md"


### PR DESCRIPTION
## Summary
- build PikaCmd from externals when updating docs
- run documentation update via local PikaCmd instead of global pika
- ensure Windows script uses built PikaCmd

## Testing
- `timeout 600 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b4bdf2565c83329cf291aff628fbe6