### PR TITLE
Use local PikaCmd for documentation scripts

### DIFF
--- a/tools/updateDocumentation.cmd
+++ b/tools/updateDocumentation.cmd
@@ -1,18 +1,13 @@
 @ECHO OFF
 CD /D "%~dp0"
-
-where pika >NUL 2>&1
-IF ERRORLEVEL 1 (
-    ECHO PikaScript not found. Install it first.
-    GOTO error
-)
+CALL "..\externals\PikaCmd\BuildPikaCmd.cmd" || GOTO error
 where pandoc >NUL 2>&1
 IF ERRORLEVEL 1 (
-    ECHO pandoc not found. Install it first.
-    GOTO error
+	ECHO pandoc not found. Install it first.
+	GOTO error
 )
 
-pika updateDocumentationImages.pika "..\docs\IVG Documentation.md" || GOTO error
+CALL "..\externals\PikaCmd\Pika.cmd" updateDocumentationImages.pika "..\docs\IVG Documentation.md" || GOTO error
 pandoc -s -o "..\docs\ImpD Documentation.html" --metadata title="ImpD Documentation" --include-in-header pandoc.css "..\docs\ImpD Documentation.md" || GOTO error
 pandoc -s -o "..\docs\IVG Documentation.html" --metadata title="IVG Documentation" --include-in-header pandoc.css "..\docs\IVG Documentation.md" || GOTO error
 

--- a/tools/updateDocumentation.sh
+++ b/tools/updateDocumentation.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -e -o pipefail -u
 cd "$(dirname "$0")"
-which -s pika || curl -fsSL https://nuedge.net/pikascript/install.sh | sh
-which -s pandoc || brew install pandoc
-pika updateDocumentationImages.pika "../docs/IVG Documentation.md"
+bash "../externals/PikaCmd/BuildPikaCmd.sh"
+if ! command -v pandoc >/dev/null 2>&1; then
+	echo "pandoc not found. Install it first." >&2
+	exit 1
+fi
+bash "../externals/PikaCmd/pika" updateDocumentationImages.pika "../docs/IVG Documentation.md"
 pandoc -s -o "../docs/ImpD Documentation.html" --metadata title="ImpD Documentation" --include-in-header pandoc.css "../docs/ImpD Documentation.md"
 pandoc -s -o "../docs/IVG Documentation.html" --metadata title="IVG Documentation" --include-in-header pandoc.css "../docs/IVG Documentation.md"


### PR DESCRIPTION
## Summary
- build and use the bundled PikaCmd when updating documentation
- fail early if pandoc is missing
- invoke the bundled Pika script through bash to avoid permission issues

## Testing
- `timeout 600 ./build.sh`
- `bash tools/updateDocumentation.sh` *(fails: pandoc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c00f15a08332a7a9cbae728599c6