### PR TITLE
docs: add fuzzing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ by Fredrik Lidström, a TypeScript wrapper around the legacy
 - [NuXPixels Documentation](docs/NuXPixels%20Documentation.md)
 - [ivgfont Documentation](docs/ivgfont%20Documentation.md)
 - [Developer Guide](docs/Developer%20Guide.md)
+- [Fuzzing](docs/Fuzzing.md)
 
 ## AI Usage
 

--- a/docs/Fuzzing.md
+++ b/docs/Fuzzing.md
@@ -1,0 +1,28 @@
+# Fuzzing
+
+## Building the fuzz target
+
+The `tools/IVG2PNG.cpp` program contains an `LLVMFuzzerTestOneInput` entry point guarded by the `LIBFUZZ` macro. Compile it with clang and libFuzzer using the `BuildCpp.sh` helper:
+
+```bash
+CPP_COMPILER=clang++ CPP_OPTIONS='-fsanitize=fuzzer,address -DLIBFUZZ' \
+    bash tools/BuildCpp.sh beta native output/IVGFuzz \
+    tools/IVG2PNG.cpp src/IVG.cpp src/IMPD.cpp externals/NuX/NuXPixels.cpp \
+    externals/libpng/*.c externals/zlib/*.c -I . -I externals/libpng -I externals/zlib
+```
+
+The resulting binary appears as `output/IVGFuzz` and is invoked with a directory of seed inputs:
+
+```bash
+./output/IVGFuzz corpus/
+```
+
+On macOS the clang from Xcode omits libFuzzer. Install `llvm` via Homebrew and set `CPP_COMPILER`:
+
+```bash
+CPP_COMPILER=$(brew --prefix llvm)/bin/clang++ CPP_OPTIONS='-fsanitize=fuzzer,address -DLIBFUZZ' \
+    bash tools/BuildCpp.sh beta native output/IVGFuzz \
+    tools/IVG2PNG.cpp src/IVG.cpp src/IMPD.cpp externals/NuX/NuXPixels.cpp \
+    externals/libpng/*.c externals/zlib/*.c -I . -I externals/libpng -I externals/zlib
+```
+


### PR DESCRIPTION
## Summary
- document how to build and run the libFuzzer harness for IVG
- link fuzzing guide from main README

## Testing
- `timeout 600 ./build.sh` *(terminated after logs due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f39b72048332ba4b399573071d37