### PR TITLE
Build InvalidIVGTest for regression tests

### DIFF
--- a/tools/buildAndTest.sh
+++ b/tools/buildAndTest.sh
@@ -43,10 +43,14 @@ C_SRCS=(./externals/libpng/png.c ./externals/libpng/pngerror.c ./externals/libpn
 
 # -ffp-contract=off is necessary to avoid issues with floating point optimizations that can cause differences in results
 ./tools/BuildCpp.sh $1 $2 ./output/IVG2PNG \
-		-ffp-contract=off -UTARGET_OS_MAC ./tools/IVG2PNG.cpp -DNUXPIXELS_SIMD=$simd \
-		-I ./ -I ./externals -I ./externals/libpng -I ./externals/zlib \
-		./src/IVG.cpp ./src/IMPD.cpp ./externals/NuX/NuXPixels.cpp \
-		"${C_SRCS[@]}"
+				-ffp-contract=off -UTARGET_OS_MAC ./tools/IVG2PNG.cpp -DNUXPIXELS_SIMD=$simd \
+				-I ./ -I ./externals -I ./externals/libpng -I ./externals/zlib \
+				./src/IVG.cpp ./src/IMPD.cpp ./externals/NuX/NuXPixels.cpp \
+				"${C_SRCS[@]}"
+
+./tools/BuildCpp.sh $1 $2 ./output/InvalidIVGTest \
+				-DNUXPIXELS_SIMD=$simd -I ./ -I ./externals \
+				./tests/invalidIVG.cpp ./src/IVG.cpp ./src/IMPD.cpp ./externals/NuX/NuXPixels.cpp
 
 ./tools/BuildCpp.sh $1 $2 ./output/PolygonMaskTest \
 		-DNUXPIXELS_SIMD=$simd -I ./ -I ./externals \


### PR DESCRIPTION
## Summary
- Compile the InvalidIVGTest utility in `buildAndTest.sh` so the invalid IVG suite can run

## Testing
- `SKIP_SVG=1 timeout 600 ./tools/buildAndTest.sh beta native nosimd`


------
https://chatgpt.com/codex/tasks/task_e_68b5fb3b18848332bee405cb7be28c2d