### PR TITLE
Add explicit build success message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,14 @@ timeout 600 ./build.sh
 
 Always execute this command before committing changes to verify that the build and regression tests succeed.
 
+A complete run ends with the line:
+
+```
+=== ALL BUILDS AND TESTS COMPLETED SUCCESSFULLY ===
+```
+
+If this message does not appear, the build has not finished correctly.
+
 ## Repository layout
 The project uses a consistent folder structure. Build output is written to `output/` and no source files live there. Useful locations:
 

--- a/build.cmd
+++ b/build.cmd
@@ -14,7 +14,7 @@ IF ERRORLEVEL 1 (
     CALL .\tools\ivgfiddle\buildIVGFiddle.cmd || GOTO error
 )
 ECHO.
-ECHO ALL GOOD!!
+ECHO === ALL BUILDS AND TESTS COMPLETED SUCCESSFULLY ===
 ECHO.
 EXIT /b 0
 :error

--- a/build.sh
+++ b/build.sh
@@ -18,5 +18,5 @@ else
 fi
 
 echo
-echo ALL GOOD!!
+echo "=== ALL BUILDS AND TESTS COMPLETED SUCCESSFULLY ==="
 echo


### PR DESCRIPTION
## Summary
- Print `=== ALL BUILDS AND TESTS COMPLETED SUCCESSFULLY ===` at the end of both build scripts
- Document the new completion message in AGENTS.md so builders know when the build has fully finished

## Testing
- `timeout 600 ./build.sh` *(terminated early; success message not observed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ce46ccc48332943ae5f2d8be92d2