### PR TITLE
Align radial span start rounding

### DIFF
--- a/externals/NuX/NuXPixels.cpp
+++ b/externals/NuX/NuXPixels.cpp
@@ -1015,7 +1015,8 @@ void RadialAscend::render(int x, int y, int length, SpanBuffer<Mask8>& output) c
 	const double a = 1.0 - dy * dy / (height * height);
 	const double rowWidth = (a > EPSILON) ? width * sqrt(a) : 0;
 	const double rowStart = (centerX - rowWidth);
-	const int leftEdge = minValue(maxValue(roundToInt(rowStart - x), 0), length);
+	const int rowStartInt = roundToInt(rowStart);
+	const int leftEdge = minValue(maxValue(rowStartInt - x, 0), length);
 	const int rightEdge = minValue(roundToInt(rowStart + rowWidth * 2 - x), length);
 	
 	int i = 0;
@@ -1028,16 +1029,14 @@ void RadialAscend::render(int x, int y, int length, SpanBuffer<Mask8>& output) c
 		} else {
 			assert(i == leftEdge);
 						
-			const int rowStartInt = roundToInt(rowStart);
+			const int steps = x + i - rowStartInt;
+			assert(steps >= 0);
 			const double dx = rowStartInt - centerX;
 			const double dpp = 2.0 * wk;
 			const double dp = (2.0 * dx - 1.0) * wk + dpp * 0.5;
 			const double d = dy * dy * hk + dx * dx * wk + dp * 0.5;
 			assert(dpp >= 0.0);
 			const unsigned int dppi = roundToInt(dpp);
-
-			const int steps = x + i - rowStartInt;
-			assert(steps >= 0);
 			assert(steps < (1 << 16));
 			const int dp0 = roundToInt(dp);
 			
@@ -1082,7 +1081,7 @@ void RadialAscend::render(int x, int y, int length, SpanBuffer<Mask8>& output) c
 				}
 
 				if (allZ < (1 << (30 - 8))) {														// Shift input and output if maximum z is small to attain 256 times higher resolution for the relatively small sqrt table lookup.
-					const int sqrtShift = ((30 - RADIAL_SQRT_BITS) - 8); 							// Input is "up-shifted" twice as much (8) as the output is down-shifted (4), since the output multiplier should be the square-root of the input multiplier.
+					const int sqrtShift = ((30 - RADIAL_SQRT_BITS) - 8);							// Input is "up-shifted" twice as much (8) as the output is down-shifted (4), since the output multiplier should be the square-root of the input multiplier.
 					pixels[0] = ((255 << 4) - 255 + sqrtTable[z0 >> sqrtShift]) >> 4;				// Since the table is inversed (see constructor), we use an algebraic trick to perform: 255 - (255 - table) >> 4.
 					pixels[1] = ((255 << 4) - 255 + sqrtTable[z1 >> sqrtShift]) >> 4;
 					pixels[2] = ((255 << 4) - 255 + sqrtTable[z2 >> sqrtShift]) >> 4;
@@ -1149,7 +1148,7 @@ struct PolygonMask::Segment::Order {
 };
 
 PolygonMask::PolygonMask(const Path& path, const IntRect& clipBounds, const FillRule& fillRule)
-       : segments(), fillRule(fillRule), row(0), engagedStart(0), engagedEnd(0), coverageDelta()
+	   : segments(), fillRule(fillRule), row(0), engagedStart(0), engagedEnd(0), coverageDelta()
 {
 	// Clamp the clip rectangle to the numeric limits handled by the rasterizer.
 	IntRect cb = clipBounds;


### PR DESCRIPTION
## Summary
- round the radial row start once and reuse for edge and step calculations
- drop negative-step clamp and assert non-negative steps

## Testing
- `timeout 600 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b6f80e4f50833295ba8beeafbcb00c