### PR TITLE
Limit IVG coordinates to one million

### DIFF
--- a/src/IVG.cpp
+++ b/src/IVG.cpp
@@ -46,7 +46,7 @@ using IMPD::UniChar;
 const double DEGREES = PI2 / 360.0;
 const double MIN_CURVE_QUALITY = 0.001;
 const double MAX_CURVE_QUALITY = 100.0;
-const double COORDINATE_LIMIT = double(INT_MAX) / 256.0;
+const double COORDINATE_LIMIT = 1000000.0;
 
 static StringIt eatSpace(StringIt p, const StringIt& e) {
 	while (p != e && (*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n')) ++p;


### PR DESCRIPTION
## Summary
- Restrict coordinate parsing to ±1,000,000 to reject extreme IVG values early.

## Testing
- `timeout 600 ./build.sh`
- `CPP_COMPILER=clang++ CPP_OPTIONS="-fsanitize=fuzzer,address -DLIBFUZZ" bash tools/BuildCpp.sh beta native output/IVGFuzz -I . -I externals/ -I externals/libpng tools/IVG2PNG.cpp src/IVG.cpp src/IMPD.cpp externals/NuX/NuXPixels.cpp`
- `./output/IVGFuzz fuzzCrashes/crash-63e6f0316e84ab038a9fcac1132a2b071afe6315`


------
https://chatgpt.com/codex/tasks/task_e_68b722fa18b88332b45296522e10360c