### PR TITLE
Validate ellipse aspect ratio before arc sweep

### DIFF
--- a/src/IVG.cpp
+++ b/src/IVG.cpp
@@ -162,6 +162,10 @@ static void appendArcSegment(const Vertex& startPos, const Vertex& endPos, doubl
 	const double largeArcSign = (largeArcFlag != 0 ? 1.0 : -1.0);
 	const double sweepSign = (sweepFlag != 0 ? largeArcSign : -largeArcSign);
 	const double aspectRatio = rx / ry;
+	if (aspectRatio <= 0.0 || aspectRatio >= 10000000000.0) {
+		Interpreter::throwRunTimeError(String("ellipse aspect ratio out of range (0..1e10): ")
+				+ Interpreter::toString(aspectRatio));
+	}
 	const double l = dx * dx + (aspectRatio * dy) * (aspectRatio * dy);
 	const double b = max(4.0 * rx * rx / l - 1.0, EPSILON);
 	const double a = sweepSign * sqrt(b * 0.25);


### PR DESCRIPTION
## Summary
- guard appendArcSegment from extreme ellipse aspect ratios
- report invalid radii with Interpreter::throwRunTimeError

## Testing
- `timeout 600 ./build.sh` *(fails: arcPaths.png differ)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f65aef5c8332b21f36e2139162f9