### PR TITLE
Add explicit failure messages to vector test scripts

### DIFF
--- a/tools/testIVG.cmd
+++ b/tools/testIVG.cmd
@@ -4,13 +4,13 @@ CD /D "%~dp0\..\tests"
 
 SET update=0
 IF /I "%~1"=="update" (
-    SET update=1
-    SHIFT
+	SET update=1
+	SHIFT
 )
 IF "%~1"=="" (
-    SET exe="../output/IVG2PNG"
+	SET exe="../output/IVG2PNG"
 ) ELSE (
-    SET exe="%~1"
+	SET exe="%~1"
 )
 SET fonts=..\fonts
 SET images=.
@@ -21,24 +21,29 @@ MKDIR %tempDir%
 
 SET fail=0
 FOR %%f IN (ivg\*.ivg) DO (
-    ECHO Doing %%f
-    ECHO.
-    IF "%%~nf"=="huge" (
-        %exe% --fast --images %images% --fonts %fonts% "%%f" "%tempDir%\%%~nf.png"
-    ) ELSE (
-        %exe% --images %images% --fonts %fonts% "%%f" "%tempDir%\%%~nf.png"
-    )
-    IF ERRORLEVEL 1 SET fail=1
-    IF %update%==1 (
-        COPY "%tempDir%\%%~nf.png" "png\%%~nf.png" >NUL
-    ) ELSE (
-        fc "%tempDir%\%%~nf.png" "png\%%~nf.png"
-        IF ERRORLEVEL 1 SET fail=1
-    )
-    ECHO.
-    ECHO.
+	ECHO Doing %%f
+	ECHO.
+	IF "%%~nf"=="huge" (
+		%exe% --fast --images %images% --fonts %fonts% "%%f" "%tempDir%\%%~nf.png"
+	) ELSE (
+		%exe% --images %images% --fonts %fonts% "%%f" "%tempDir%\%%~nf.png"
+	)
+	IF ERRORLEVEL 1 SET fail=1
+	IF %update%==1 (
+		COPY "%tempDir%\%%~nf.png" "png\%%~nf.png" >NUL
+	) ELSE (
+		fc "%tempDir%\%%~nf.png" "png\%%~nf.png"
+		IF ERRORLEVEL 1 SET fail=1
+	)
+	ECHO.
+	ECHO.
 )
 DEL /q %tempDir%\*.png >NUL 2>NUL
 RMDIR %tempDir% >NUL 2>NUL
+IF %fail% NEQ 0 (
+	ECHO.
+	ECHO === IVG TESTS FAILED === 1>&2
+	ECHO.
+)
 
 EXIT /b %fail%

--- a/tools/testIVG.sh
+++ b/tools/testIVG.sh
@@ -21,31 +21,36 @@ echo Using temporary dir: "$tmp"
 fail=0
 set +e
 for f in ./ivg/*.ivg; do
-    n=${f#./ivg/}
-    n=${n%.ivg}
-    echo Doing "$n"
-    echo
-    args=""
-    if [ "$n" = "huge" ]; then
-        args="--fast"
-    fi
-    $EXE $args --images "$IMAGES" --fonts "$FONTS" "$f" "$tmp/$n.png"
-    if [ $? -ne 0 ]; then
-        fail=1
-        echo
-        echo
-        continue
-    fi
-    if [ "$UPDATE" -eq 1 ]; then
-        cp "$tmp/$n.png" "./png/$n.png"
-    else
-        cmp "$tmp/$n.png" "./png/$n.png"
-        [ $? -ne 0 ] && fail=1
-    fi
-    echo
-    echo
+	n=${f#./ivg/}
+	n=${n%.ivg}
+	echo Doing "$n"
+	echo
+	args=""
+	if [ "$n" = "huge" ]; then
+		args="--fast"
+	fi
+	$EXE $args --images "$IMAGES" --fonts "$FONTS" "$f" "$tmp/$n.png"
+	if [ $? -ne 0 ]; then
+		fail=1
+		echo
+		echo
+		continue
+	fi
+	if [ "$UPDATE" -eq 1 ]; then
+		cp "$tmp/$n.png" "./png/$n.png"
+	else
+		cmp "$tmp/$n.png" "./png/$n.png"
+		[ $? -ne 0 ] && fail=1
+	fi
+	echo
+	echo
 done
 set -e
 rm -rf "$tmp"/*.png
 rmdir "$tmp"
+if [ $fail -ne 0 ]; then
+	echo
+	echo "=== IVG TESTS FAILED ===" >&2
+	echo
+fi
 exit $fail

--- a/tools/testSVG.cmd
+++ b/tools/testSVG.cmd
@@ -4,13 +4,13 @@ CD /D "%~dp0\..\tests\svg"
 
 SET update=0
 IF /I "%~1"=="update" (
-    SET update=1
-    SHIFT
+	SET update=1
+	SHIFT
 )
 IF "%~1"=="" (
-    SET exe=..\..\output\IVG2PNG
+	SET exe=..\..\output\IVG2PNG
 ) ELSE (
-    SET exe=%~1
+	SET exe=%~1
 )
 SET fonts=..\..\fonts
 
@@ -20,32 +20,38 @@ MKDIR %tempDir%
 
 SET fail=0
 FOR %%n IN (
-    circle rect ellipse line path group color-names stroke-fill viewbox multi-path polygon polyline units percentage transform skew matrix gradient gradient-stops gradient-radial gradient-transform defs-use opacity text text-stroke resvg_tests_shapes_rect_em-values resvg_tests_shapes_rect_vw-and-vh-values resvg_tests_painting_color_inherit "resvg_tests_masking_clipPath_clipPathUnits=objectBoundingBox" resvg_tests_painting_marker_marker-on-line
+	circle rect ellipse line path group color-names stroke-fill viewbox multi-path polygon polyline units percentage transform skew matrix gradient gradient-stops gradient-radial gradient-transform defs-use opacity text text-stroke resvg_tests_shapes_rect_em-values resvg_tests_shapes_rect_vw-and-vh-values resvg_tests_painting_color_inherit "resvg_tests_masking_clipPath_clipPathUnits=objectBoundingBox" resvg_tests_painting_marker_marker-on-line
 ) DO (
-    ECHO Testing %%~n
-    node ..\..\tools\svg2ivg.js "supported/%%~n.svg" 500,500 > "%tempDir%\%%~n.tmp"
-    IF ERRORLEVEL 1 SET fail=1
-    more +1 "%tempDir%\%%~n.tmp" > "%tempDir%\%%~n.ivg"
-    DEL "%tempDir%\%%~n.tmp"
-    %exe% --fonts %fonts% --background white "%tempDir%\%%~n.ivg" "%tempDir%\%%~n.png"
-    IF ERRORLEVEL 1 SET fail=1
-    IF %update%==1 (
-        COPY "%tempDir%\%%~n.ivg" "supported\%%~n.ivg" >NUL
-        COPY "%tempDir%\%%~n.png" "supported\%%~n.png" >NUL
-    ) ELSE (
-        fc "%tempDir%\%%~n.ivg" "supported\%%~n.ivg"
-        IF ERRORLEVEL 1 SET fail=1
-        IF EXIST "supported\%%~n.png" (
-            fc "%tempDir%\%%~n.png" "supported\%%~n.png"
-            IF ERRORLEVEL 1 SET fail=1
-        ) ELSE (
-            ECHO Missing golden PNG: supported\%%~n.png
-            SET fail=1
-        )
-    )
-    ECHO.
-    ECHO.
+	ECHO Testing %%~n
+	node ..\..\tools\svg2ivg.js "supported/%%~n.svg" 500,500 > "%tempDir%\%%~n.tmp"
+	IF ERRORLEVEL 1 SET fail=1
+	more +1 "%tempDir%\%%~n.tmp" > "%tempDir%\%%~n.ivg"
+	DEL "%tempDir%\%%~n.tmp"
+	%exe% --fonts %fonts% --background white "%tempDir%\%%~n.ivg" "%tempDir%\%%~n.png"
+	IF ERRORLEVEL 1 SET fail=1
+	IF %update%==1 (
+		COPY "%tempDir%\%%~n.ivg" "supported\%%~n.ivg" >NUL
+		COPY "%tempDir%\%%~n.png" "supported\%%~n.png" >NUL
+	) ELSE (
+		fc "%tempDir%\%%~n.ivg" "supported\%%~n.ivg"
+		IF ERRORLEVEL 1 SET fail=1
+		IF EXIST "supported\%%~n.png" (
+			fc "%tempDir%\%%~n.png" "supported\%%~n.png"
+			IF ERRORLEVEL 1 SET fail=1
+		) ELSE (
+			ECHO Missing golden PNG: supported\%%~n.png
+			SET fail=1
+		)
+	)
+	ECHO.
+	ECHO.
 )
 DEL /q "%tempDir%\*" >NUL 2>NUL
 RMDIR "%tempDir%"
+IF %fail% NEQ 0 (
+	ECHO.
+	ECHO === SVG TESTS FAILED === 1>&2
+	ECHO.
+)
+
 EXIT /b %fail%

--- a/tools/testSVG.sh
+++ b/tools/testSVG.sh
@@ -56,4 +56,9 @@ for NAME in circle rect ellipse line path group color-names stroke-fill viewbox 
 done
 set -e
 rm -rf "$TMP"
+if [ $fail -ne 0 ]; then
+	echo
+	echo "=== SVG TESTS FAILED ===" >&2
+	echo
+fi
 exit $fail


### PR DESCRIPTION
## Summary
- Emit `=== IVG TESTS FAILED ===` when IVG image comparisons fail
- Emit `=== SVG TESTS FAILED ===` when SVG conversion tests fail

## Testing
- `timeout 600 ./build.sh` *(terminated early; build output ended before success message)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4a2ff6dc8332a8b06f9371bbcce8