### PR TITLE
Document IVG-3 mask controls

### DIFF
--- a/docs/IVG Documentation.html
+++ b/docs/IVG Documentation.html
@@ -332,6 +332,7 @@ through <code>define image</code> and <code>IMAGE</code>.</li>
 <li><code>IVG-3</code> adds <code>LINE</code>, <code>POLYGON</code>, and
 an instruction-list form for <code>PATH</code> (including
 <code>define path</code>).</li>
+<li><code>IVG-3</code> also introduces mask controls: the <code>mask invert</code> and <code>mask reset</code> instructions, plus an updated <code>mask inverted:yes</code> option that inverts only the mask drawn inside the current definition before it combines with the active mask.</li>
 </ul>
 <p>The interpreter processes all versions identically, but readers that
 only understand <code>IVG-1</code> or <code>IVG-2</code> will reject
@@ -1121,6 +1122,7 @@ current context remain masked out.</p></li>
 <li><p><code>mask reset</code> restores the mask to the state that was
 active when the current context started.</p></li>
 </ul>
+<p><em>The <code>mask invert</code> and <code>mask reset</code> commands were introduced in IVG-3. IVG-3 also changes <code>inverted:yes</code> so that it inverts only the mask definition being applied before it multiplies with the active mask; earlier specifications inverted the accumulated mask, which prevented IVG documents from restoring areas once they were masked out.</em></p>
 <p>In mask definitions, drawing directives and instructions work like
 normal, and you can even nest masks in masks. The one big difference is
 that a mask is single-channeled (grayscale effectively); therefore, all

--- a/docs/IVG Documentation.md
+++ b/docs/IVG Documentation.md
@@ -137,6 +137,7 @@ and halts rendering.
 -	`IVG-1` covers core vector drawing and styling.
 -	`IVG-2` adds text, fonts, and raster image support through `define image` and `IMAGE`.
 -	`IVG-3` adds `LINE`, `POLYGON`, and an instruction-list form for `PATH` (including `define path`).
+-	`IVG-3` also introduces mask controls: the `mask invert` and `mask reset` instructions, plus an updated `mask inverted:yes` option that inverts only the mask drawn inside the current definition before it combines with the active mask.
 
 The interpreter processes all versions identically, but readers that only understand `IVG-1` or `IVG-2` will reject
 documents marked `IVG-3`.
@@ -922,6 +923,8 @@ Syntax:
 	masked out before entering the current context remain masked out.
 
 -   `mask reset` restores the mask to the state that was active when the current context started.
+
+_The `mask invert` and `mask reset` commands were introduced in IVG-3. IVG-3 also changes `inverted:yes` so that it inverts only the mask definition being applied before it multiplies with the active mask; earlier specifications inverted the accumulated mask, which prevented IVG documents from restoring areas once they were masked out._
 
 In mask definitions, drawing directives and instructions work like normal, and you can even nest masks in masks. The one
 big difference is that a mask is single-channeled (grayscale effectively); therefore, all `<paint>` specifications use a


### PR DESCRIPTION
## Summary
- note that IVG-3 adds mask control improvements alongside the PATH instruction list
- document that mask invert/reset are IVG-3 features and describe the updated inverted:yes semantics

## Testing
- timeout 600 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68caf333da60833285b493e7de1a1396