### PR TITLE
Rename arc sweep parameter defaults

### DIFF
--- a/externals/NuX/NuXPixels.cpp
+++ b/externals/NuX/NuXPixels.cpp
@@ -480,15 +480,15 @@ Path& Path::addRect(double left, double top, double width, double height) {
 /**
 	Makes an arc by rotating a point around the center of the arc.
 **/
-Path& Path::arcSweep(double centerX, double centerY, double sweepRadians, double radiusX, double radiusY, double curveQuality) {
+Path& Path::arcSweep(double centerX, double centerY, double sweepRadians, double ratioX, double ratioY, double curveQuality) {
 	assert(-PI2 <= sweepRadians && sweepRadians <= PI2);
 	assert(0.0 < curveQuality);
 
 	const Vertex pos(getPosition());
-	const double sx = (pos.x - centerX) / radiusX;
-	const double sy = (pos.y - centerY) / radiusY;
+	const double sx = (pos.x - centerX) / ratioX;
+	const double sy = (pos.y - centerY) / ratioY;
 
-	const double major = maxValue(fabs(radiusX), fabs(radiusY));
+	const double major = maxValue(fabs(ratioX), fabs(ratioY));
 	const double diameter = maxValue(major, 1.0) * 2.0 * sqrt(sx * sx + sy * sy);
 
 	double rx, ry;
@@ -508,31 +508,31 @@ Path& Path::arcSweep(double centerX, double centerY, double sweepRadians, double
 		px = nx;
 		py = ny;
 		r += t;
-		lineTo(centerX + px * radiusX, centerY + py * radiusY);
+		lineTo(centerX + px * ratioX, centerY + py * ratioY);
 	}
 	rx = cos(sweepRadians);
 	ry = sin(sweepRadians);
 	px = sx * rx - sy * ry;
 	py = sx * ry + sy * rx;
-	lineTo(centerX + px * radiusX, centerY + py * radiusY);
+	lineTo(centerX + px * ratioX, centerY + py * ratioY);
 
 	return *this;
 }
 
-Path& Path::arcMove(double centerX, double centerY, double sweepRadians, double radiusX, double radiusY) {
+Path& Path::arcMove(double centerX, double centerY, double sweepRadians, double ratioX, double ratioY) {
 	assert(-PI2 <= sweepRadians && sweepRadians <= PI2);
 
 	const Vertex pos(getPosition());
-	const double sx = (pos.x - centerX) / radiusX;
-	const double sy = (pos.y - centerY) / radiusY;
+	const double sx = (pos.x - centerX) / ratioX;
+	const double sy = (pos.y - centerY) / ratioY;
 
 	double rx = cos(sweepRadians);
 	double ry = sin(sweepRadians);
 	double px = sx * rx - sy * ry;
 	double py = sx * ry + sy * rx;
 
-	const double endX = centerX + px * radiusX;
-	const double endY = centerY + py * radiusY;
+	const double endX = centerX + px * ratioX;
+	const double endY = centerY + py * ratioY;
 
 	if (!instructions.empty() && instructions.back().first == MOVE) {
 		instructions.back().second = Vertex(endX, endY);

--- a/externals/NuX/NuXPixels.h
+++ b/externals/NuX/NuXPixels.h
@@ -311,8 +311,8 @@ class Path {
 	public:		Path& lineTo(double x, double y);
 	public:		Path& quadraticTo(double controlPointX, double controlPointY, double x, double y, double curveQuality = 1.0);
 	public:		Path& cubicTo(double cpBeginX, double cpBeginY, double cpEndX, double cpEndY, double x, double y, double curveQuality = 1.0);
-	public:		Path& arcSweep(double centerX, double centerY, double sweepRadians, double radiusX, double radiusY, double curveQuality = 1.0);
-	public:		Path& arcMove(double centerX, double centerY, double sweepRadians, double radiusX, double radiusY);
+	public:		Path& arcSweep(double centerX, double centerY, double sweepRadians, double ratioX = 1.0, double ratioY = 1.0, double curveQuality = 1.0);
+	public:		Path& arcMove(double centerX, double centerY, double sweepRadians, double ratioX = 1.0, double ratioY = 1.0);
 	public:		Path& append(const Path& p);
 	public:		Path& addLine(double startX, double startY, double endX, double endY);
 	public:		Path& addRect(double left, double top, double width, double height); // FIX : <- phase out? only have addRect(Rect<double>)?


### PR DESCRIPTION
## Summary
- rename the arc sweep and move parameter names to ratioX/ratioY and default them to 1.0 for clarity
- update the NuXPixels implementation to use the new ratio terminology consistently

## Testing
- timeout 600 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68cda6b098bc8332a7698e54fb114f7f