### PR TITLE
Simplify math function dispatch order

### DIFF
--- a/src/IMPD.cpp
+++ b/src/IMPD.cpp
@@ -264,48 +264,54 @@ static double computeHypot(double x, double y) {
 	return hypot(x, y);
 }
 
-const Interpreter::MathFunction Interpreter::MATH_FUNCTIONS[MATH_FUNCTION_COUNT] = {
-	{ 1, Interpreter::MathDispatch((double (*)(double))(fabs)) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(acos)) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(asin)) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(atan)) },
-	{ 2, Interpreter::MathDispatch(computeAtan2) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(ceil)) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(cos)) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(cosh)) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(exp)) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(floor)) },
-	{ 1, Interpreter::MathDispatch(checkedLog) },
-	{ 1, Interpreter::MathDispatch(checkedLog10) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(sin)) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(sinh)) },
-	{ 1, Interpreter::MathDispatch(checkedSqrt) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(tan)) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(tanh)) },
-	{ 1, Interpreter::MathDispatch((double (*)(double))(round)) },
-	{ 2, Interpreter::MathDispatch(computeHypot) }
+double (*const Interpreter::UNARY_MATH_FUNCTIONS[UNARY_MATH_FUNCTION_COUNT])(double) = {
+	(double (*)(double))(fabs),
+	(double (*)(double))(acos),
+	(double (*)(double))(asin),
+	(double (*)(double))(atan),
+	(double (*)(double))(ceil),
+	(double (*)(double))(cos),
+	(double (*)(double))(cosh),
+	(double (*)(double))(exp),
+	(double (*)(double))(floor),
+	checkedLog,
+	checkedLog10,
+	(double (*)(double))(sin),
+	(double (*)(double))(sinh),
+	checkedSqrt,
+	(double (*)(double))(tan),
+	(double (*)(double))(tanh),
+	(double (*)(double))(round)
 };
 
+double (*const Interpreter::BINARY_MATH_FUNCTIONS[BINARY_MATH_FUNCTION_COUNT])(double, double) = {
+	computeAtan2,
+	computeHypot
+};
 const Char Interpreter::ESCAPE_CHARS[ESCAPE_CODE_COUNT] = {	 'a',  'b',	 'f',  'n',	 'r',  't',	 'v' };
 const Char Interpreter::ESCAPE_CODES[ESCAPE_CODE_COUNT] = { '\a', '\b', '\f', '\n', '\r', '\t', '\v' };
 
 /* Built with QuickHashGen */
 int Interpreter::findFunction(int n /* string length */, const char* s /* string (zero terminated) */) {
 	static const char* STRINGS[22] = {
-		"abs", "acos", "asin", "atan", "atan2", "ceil", "cos", "cosh", "exp", "floor", 
-		"log", "log10", "sin", "sinh", "sqrt", "tan", "tanh", "round", "hypot", "pi", 
+		"abs", "acos", "asin", "atan", "ceil", "cos", "cosh", "exp", "floor", "log", 
+		"log10", "sin", "sinh", "sqrt", "tan", "tanh", "round", "atan2", "hypot", "pi", 
 		"len", "def"
 	};
-	static const int HASH_TABLE[64] = {
-		-1, -1, -1, -1, 17, -1, 13, 12, -1, -1, -1, 7, 6, 8, -1, 18, 
-		-1, -1, -1, -1, -1, -1, 11, -1, 10, -1, 9, -1, -1, -1, -1, 1, 
-		-1, 2, 19, -1, -1, -1, 16, 15, -1, -1, -1, -1, 4, 3, -1, 21, 
-		-1, -1, 14, -1, -1, -1, -1, 20, 0, 5, -1, -1, -1, -1, -1, -1
+	static const int HASH_TABLE[128] = {
+		19, -1, -1, -1, 5, -1, -1, 8, -1, -1, -1, -1, 11, -1, -1, -1, 
+		-1, 6, -1, 0, -1, -1, -1, -1, -1, -1, 13, -1, 14, -1, -1, -1, 
+		-1, -1, -1, -1, 21, -1, 10, -1, -1, 1, -1, -1, -1, -1, -1, -1, 
+		-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
+		18, -1, -1, -1, -1, -1, -1, -1, -1, 4, -1, -1, -1, -1, -1, 2, 
+		7, 17, -1, -1, 20, -1, 12, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
+		-1, -1, -1, -1, -1, -1, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
+		3, -1, 16, -1, 9, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
 	};
 	const unsigned char* p = (const unsigned char*) s;
 	assert(s[n] == '\0');
 	if (n < 2 || n > 5) return -1;
-	int stringIndex = HASH_TABLE[(((0u + p[1]) << 2 ^ p[2]) - n) & 63u];
+	int stringIndex = HASH_TABLE[(p[2] * (p[1] ^ n)) & 127u];
 	return (stringIndex >= 0 && strcmp(s, STRINGS[stringIndex]) == 0) ? stringIndex : -1;
 }
 
@@ -1108,51 +1114,41 @@ StringIt Interpreter::evaluateOuter(StringIt b, const StringIt& e, EvaluationVal
 					if (call == e || *call != '(') throwBadSyntax("Missing \"(\".");
 					++call;
 					const bool isMathFunction = (funcIndex < MATH_FUNCTION_COUNT);
-					const int expectedArgs = (isMathFunction ? MATH_FUNCTIONS[funcIndex].arity : 1);
-					EvaluationValue firstArg;
-					EvaluationValue secondArg;
+				const FunctionIndex function = static_cast<FunctionIndex>(funcIndex);
+				const bool isUnaryMath = (funcIndex < UNARY_MATH_FUNCTION_COUNT);
+				EvaluationValue firstArg;
+				call = eatWhite(call, e);
+				StringIt next = evaluateInner(call, e, firstArg, COMMA, dry);
+				if (next == call) throwBadSyntax("Syntax error.");
+				call = eatWhite(next, e);
+				EvaluationValue secondArg;
+				if (isMathFunction && !isUnaryMath) {
+					if (call == e || *call != ',') throwBadSyntax("Missing \",\".");
+					++call;
 					call = eatWhite(call, e);
-					if (call == e) throwBadSyntax("Missing \")\".");
-					if (*call == ')') throwBadSyntax("Missing function argument.");
-					StringIt next = evaluateInner(call, e, firstArg, COMMA, dry);
+					next = evaluateInner(call, e, secondArg, COMMA, dry);
 					if (next == call) throwBadSyntax("Syntax error.");
 					call = eatWhite(next, e);
-					if (call == e) throwBadSyntax("Missing \")\".");
-					if (expectedArgs == 2) {
-						if (*call == ')') throwBadSyntax("Wrong number of function arguments.");
-						if (*call != ',') throwBadSyntax("Expected ','.");
-						++call;
-						call = eatWhite(call, e);
-						if (call == e) throwBadSyntax("Missing \")\".");
-						if (*call == ')') throwBadSyntax("Missing function argument.");
-						next = evaluateInner(call, e, secondArg, COMMA, dry);
-						if (next == call) throwBadSyntax("Syntax error.");
-						call = eatWhite(next, e);
-						if (call == e) throwBadSyntax("Missing \")\".");
-						if (*call == ',') throwBadSyntax("Too many arguments.");
-						if (*call != ')') throwBadSyntax("Missing \")\".");
-					} else {
-						if (*call == ',') throwBadSyntax("Wrong number of function arguments.");
-						if (*call != ')') throwBadSyntax("Missing \")\".");
-					}
-					++call;
-					if (isMathFunction) {
-						const MathFunction& math = MATH_FUNCTIONS[funcIndex];
-						if (!dry) {
-							errno = 0;
-							double result;
-							if (math.arity == 1) {
-								result = math.dispatch.unary(static_cast<double>(firstArg));
-							} else {
-								result = math.dispatch.binary(static_cast<double>(firstArg), static_cast<double>(secondArg));
-							}
-							if (errno != 0) throwRunTimeError("Math error.");
-							if (!isFinite(result)) throwRunTimeError("Number overflow.");
-							v = result;
+				}
+					if (call == e || *call != ')') throwBadSyntax("Missing \")\".");
+				++call;
+				if (isMathFunction) {
+					if (!dry) {
+						errno = 0;
+						double result;
+						if (isUnaryMath) {
+							result = UNARY_MATH_FUNCTIONS[funcIndex](static_cast<double>(firstArg));
+						} else {
+							const int binaryIndex = funcIndex - UNARY_MATH_FUNCTION_COUNT;
+							result = BINARY_MATH_FUNCTIONS[binaryIndex](static_cast<double>(firstArg), static_cast<double>(secondArg));
 						}
-					} else if (funcIndex == LEN_FUNCTION) {
+						if (errno != 0) throwRunTimeError("Math error.");
+						if (!isFinite(result)) throwRunTimeError("Number overflow.");
+						v = result;
+					}
+				} else if (function == LEN_FUNCTION) {
 						if (!dry) v = static_cast<double>(static_cast<String>(firstArg).size());
-					} else if (funcIndex == DEF_FUNCTION) {
+					} else if (function == DEF_FUNCTION) {
 						if (!dry) {
 							String dummyValue;
 							const String name = firstArg;

--- a/src/IMPD.h
+++ b/src/IMPD.h
@@ -56,6 +56,8 @@ const int NUMBER_PRECISION_DIGITS = 13;
 const double NUMBER_PRECISION_MAGNITUDE = 1e-13;
 
 const int MATH_FUNCTION_COUNT = 19;
+const int BINARY_MATH_FUNCTION_COUNT = 2;
+const int UNARY_MATH_FUNCTION_COUNT = MATH_FUNCTION_COUNT - BINARY_MATH_FUNCTION_COUNT;
 const int BUILT_IN_INSTRUCTION_COUNT = 11;
 const int ESCAPE_CODE_COUNT = 7;
 
@@ -267,7 +269,6 @@ class Interpreter {
 				ACOS_FUNCTION,
 				ASIN_FUNCTION,
 				ATAN_FUNCTION,
-				ATAN2_FUNCTION,
 				CEIL_FUNCTION,
 				COS_FUNCTION,
 				COSH_FUNCTION,
@@ -281,24 +282,15 @@ class Interpreter {
 				TAN_FUNCTION,
 				TANH_FUNCTION,
 				ROUND_FUNCTION,
+				ATAN2_FUNCTION,
 				HYPOT_FUNCTION,
 				PI_FUNCTION,
 				LEN_FUNCTION,
 				DEF_FUNCTION,
 				FUNCTION_LOOKUP_COUNT
 			};
-	protected:	union MathDispatch {
-				MathDispatch() : unary(0) { }
-				MathDispatch(double (*fn)(double)) : unary(fn) { }
-				MathDispatch(double (*fn)(double, double)) : binary(fn) { }
-				double (*unary)(double);
-				double (*binary)(double, double);
-			};
-	protected:	struct MathFunction {
-				int arity;
-				MathDispatch dispatch;
-			};
-	protected:	static const MathFunction MATH_FUNCTIONS[MATH_FUNCTION_COUNT];
+	protected:	static double (*const UNARY_MATH_FUNCTIONS[UNARY_MATH_FUNCTION_COUNT])(double);
+	protected:	static double (*const BINARY_MATH_FUNCTIONS[BINARY_MATH_FUNCTION_COUNT])(double, double);
 	protected:	static int findBuiltInInstruction(int n, const char* s);
 	protected:	static int findFunction(int n, const char* s);
 	protected:	static const Char ESCAPE_CHARS[ESCAPE_CODE_COUNT];


### PR DESCRIPTION
## Summary
- move the ATAN2 and HYPOT function indices to the end of the math enumeration
- streamline math function invocation by keying directly on unary and binary table counts
- regenerate the math function lookup hash with the new ordering using QuickHashGen

## Testing
- timeout 600 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68daa9958520833287e0cdf651d5d549