### PR TITLE
Handle IVG preview OOM crashes by reloading the rasterizer

### DIFF
--- a/tools/ivg-vscode/media/previewShared.js
+++ b/tools/ivg-vscode/media/previewShared.js
@@ -493,6 +493,23 @@
 				Settings.write(STORAGE_KEYS.VECTOR_SCALING, vectorScalingEnabled ? "1" : "0");
 			}
 
+			function setVectorScalingEnabled(nextState, options) {
+				const settings = options || {};
+				const normalized = nextState === true;
+				if (vectorScalingEnabled === normalized) {
+					return;
+				}
+				vectorScalingEnabled = normalized;
+				if (settings.persist !== false) {
+					persistVectorScaling();
+				}
+				reflectVectorScalingState();
+				applyZoom();
+				if (rerenderCallback && settings.notify !== false) {
+					rerenderCallback("vector-toggle");
+				}
+			}
+
 			function applyZoom() {
 				if (ivgCanvas === null) {
 					return;
@@ -603,8 +620,7 @@
 					currentZoom = clampZoom(storedZoom);
 				}
 				const storedVector = Settings.read(STORAGE_KEYS.VECTOR_SCALING, "0");
-				vectorScalingEnabled = storedVector === "1";
-				reflectVectorScalingState();
+				setVectorScalingEnabled(storedVector === "1", { persist: false, notify: false });
 				populateZoomOptions();
 				applyZoom();
 				withElement(zoomOutButton, function attachZoomOut(button) {
@@ -628,13 +644,7 @@
 				withElement(vectorScalingToggle, function attachVectorToggle(button) {
 					button.addEventListener("click", function toggleVectorScaling(event) {
 						event.preventDefault();
-						vectorScalingEnabled = !vectorScalingEnabled;
-						persistVectorScaling();
-						reflectVectorScalingState();
-						applyZoom();
-						if (rerenderCallback) {
-							rerenderCallback("vector-toggle");
-						}
+						setVectorScalingEnabled(!vectorScalingEnabled);
 					});
 				});
 				withElement(zoomLevelSelect, function attachZoomSelect(select) {
@@ -698,6 +708,10 @@
 				applyZoom();
 			}
 
+			function getBaseMetrics() {
+				return baseMetrics;
+			}
+
 			function getRasterScale(pixelRatio) {
 				if (vectorScalingEnabled) {
 					return 1;
@@ -722,6 +736,8 @@
 				getRasterScale: getRasterScale,
 				usesVectorScaling: usesVectorScaling,
 				getZoom: getZoom,
+				setVectorScalingEnabled: setVectorScalingEnabled,
+				getBaseMetrics: getBaseMetrics,
 			};
 		})();
 
@@ -736,6 +752,8 @@
 		let hasSuccessfulRender = false;
 		let currentDocumentUri = null;
 		let lastSuccessfulRenderUri = null;
+		let moduleRecoveryPromise = null;
+		let suppressFailureStatus = false;
 
 		function notifyHost(level, message, options) {
 			const text = typeof message === "string" ? message : "";
@@ -760,6 +778,61 @@
 				notifyOptions.durationMs = opts.durationMs;
 			}
 			notifyHost(level, text, notifyOptions);
+		}
+
+		function describeError(error) {
+			if (error instanceof Error && typeof error.message === "string") {
+				return error.message;
+			}
+			if (error && typeof error === "object" && typeof error.message === "string") {
+				return error.message;
+			}
+			if (typeof error === "string") {
+				return error;
+			}
+			try {
+				return JSON.stringify(error);
+			} catch (serializationError) {
+				return String(error);
+			}
+		}
+
+		function isOutOfMemoryError(message) {
+			if (typeof message !== "string") {
+				return false;
+			}
+			const normalized = message.toLowerCase();
+			return normalized.includes("oom") || normalized.includes("out of memory");
+		}
+
+		function recoverFromOutOfMemory(message) {
+			const reloadModule = typeof global.__ivgReloadModule === "function" ? global.__ivgReloadModule : null;
+			if (moduleRecoveryPromise) {
+				return;
+			}
+			if (!reloadModule) {
+				setStatus("Renderer ran out of memory. Reload the preview to continue.", { level: "error" });
+				return;
+			}
+			suppressFailureStatus = true;
+			moduleReady = false;
+			pendingSource = currentSource;
+			pendingUri = currentDocumentUri;
+			if (typeof ZoomController.setVectorScalingEnabled === "function") {
+				ZoomController.setVectorScalingEnabled(false, { notify: false });
+			}
+			setStatus("Renderer ran out of memory. Restarting…", { level: "error" });
+			moduleRecoveryPromise = reloadModule()
+				.then(function handleRecoverySuccess() {
+					moduleRecoveryPromise = null;
+				})
+				.catch(function handleRecoveryFailure(error) {
+					moduleRecoveryPromise = null;
+					suppressFailureStatus = false;
+					trace("Failed to restart IVG rasterizer module.");
+					trace(describeError(error));
+					setStatus("Failed to restart renderer after running out of memory.", { level: "error" });
+				});
 		}
 
 		function clearTrace() {
@@ -958,7 +1031,11 @@
 				}
 			} catch (error) {
 				trace("Rasterization crashed");
-				trace(String(error));
+				const errorMessage = describeError(error);
+				trace(errorMessage);
+				if (isOutOfMemoryError(errorMessage)) {
+					recoverFromOutOfMemory(errorMessage);
+				}
 			}
 			if (!ok) {
 				const preserveImage = hasSuccessfulRender && isSameDocumentUri(currentDocumentUri, lastSuccessfulRenderUri);
@@ -966,9 +1043,11 @@
 					ZoomController.clearMetrics();
 				}
 				drawFailureCross({ preserveImage: preserveImage });
-				setStatus("Rendering failed. Check trace output for details.", {
-					level: "error",
-				});
+				if (!suppressFailureStatus) {
+					setStatus("Rendering failed. Check trace output for details.", {
+						level: "error",
+					});
+				}
 			}
 		}
 
@@ -1046,6 +1125,8 @@
 
 		function handleModuleInitialized(initialSource) {
 			moduleReady = true;
+			suppressFailureStatus = false;
+			moduleRecoveryPromise = null;
 			const stored = Settings.read(STORAGE_KEYS.SOURCE, "");
 			if (typeof stored === "string" && stored.length > 0) {
 				currentSource = stored;

--- a/tools/ivg-vscode/media/setupModule.js
+++ b/tools/ivg-vscode/media/setupModule.js
@@ -27,7 +27,15 @@ const moduleConfig = {
 	onRuntimeInitialized: function () {
 		moduleConfig.__runtimeReady = true;
 	},
+	onAbort: function (reason) {
+		moduleConfig.__runtimeReady = false;
+		trace("Renderer aborted: " + String(reason));
+	},
 };
+
+let moduleFactory = typeof globalObject.__ivgModuleFactory === "function" ? globalObject.__ivgModuleFactory : null;
+let moduleInstantiation = null;
+let moduleActivation = null;
 //
 // Emscripten expects a global `Module` variable to exist before the generated
 // runtime loads so configuration can be merged. Assign via `globalThis` so the
@@ -35,6 +43,55 @@ const moduleConfig = {
 // redeclaration syntax error.
 //
 globalObject.Module = moduleConfig;
+
+function instantiateModule() {
+	if (moduleInstantiation) {
+		return moduleInstantiation;
+	}
+	if (typeof moduleFactory !== "function") {
+		return Promise.reject(new Error("IVG rasterizer module is not available."));
+	}
+	globalObject.Module = moduleConfig;
+	moduleConfig.__runtimeReady = false;
+	moduleInstantiation = moduleFactory(moduleConfig)
+		.then(function handleModuleInstance(instance) {
+			globalObject.Module = instance;
+			return instance;
+		})
+		.catch(function handleModuleFailure(error) {
+			trace("Failed to instantiate IVG rasterizer module.");
+			trace(String(error));
+			throw error;
+		})
+		.finally(function clearInstantiationState() {
+			moduleInstantiation = null;
+		});
+	return moduleInstantiation;
+}
+
+function activateModule() {
+	if (moduleActivation) {
+		return moduleActivation;
+	}
+	moduleActivation = instantiateModule()
+		.then(function notifyModuleReady(instance) {
+			notifyPreviewReady(instance);
+			return instance;
+		})
+		.finally(function clearActivationState() {
+			moduleActivation = null;
+		});
+	return moduleActivation;
+}
+
+function logActivationFailure(error) {
+	trace("Failed to activate IVG rasterizer module.");
+	trace(String(error));
+}
+
+globalObject.__ivgReloadModule = function reloadModule() {
+	return activateModule();
+};
 
 function notifyPreviewReady(moduleInstance) {
 	let initSource = localStorage.getItem("ivgSource");
@@ -46,14 +103,26 @@ function notifyPreviewReady(moduleInstance) {
 	}
 }
 
+function ensureModuleFactory(candidate) {
+	if (typeof candidate === "function") {
+		moduleFactory = candidate;
+		globalObject.__ivgModuleFactory = candidate;
+	}
+}
+
 window.addEventListener("load", function () {
 	const currentModule = globalObject.Module;
 	if (typeof currentModule === "function") {
-		currentModule(moduleConfig).then(function (instance) {
-			globalObject.Module = instance;
-			notifyPreviewReady(instance);
-		});
-	} else if (moduleConfig.__runtimeReady && currentModule && currentModule.FS) {
+		ensureModuleFactory(currentModule);
+		activateModule().catch(logActivationFailure);
+		return;
+	}
+	ensureModuleFactory(globalObject.__ivgModuleFactory);
+	if (moduleConfig.__runtimeReady && currentModule && currentModule.FS) {
 		notifyPreviewReady(currentModule);
+		return;
+	}
+	if (typeof moduleFactory === "function") {
+		activateModule().catch(logActivationFailure);
 	}
 });


### PR DESCRIPTION
## Summary
- add a reusable module activation helper so the VS Code preview can reinstantiate the WASM rasterizer after aborts
- detect out-of-memory errors in the preview client, disable vector zoom, and queue a renderer restart while keeping the current document loaded

## Testing
- timeout 600 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68e1226276108332adcc08de331c3992