### PR TITLE
Fix snapshot playback with multiple meta blocks

### DIFF
--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -2113,6 +2113,7 @@ class SnapshotScheduler {
 		}
 
 		for (size_t i = 0; i < threads.size(); ++i) {
+			jobAvailable.signal();
 			threads[i]->join();
 		}
 		workers.clear();
@@ -2196,6 +2197,7 @@ class SnapshotScheduler {
 			}
 		}
 		resultAvailable.signal();
+		jobAvailable.signal();
 	}
 
 	uint32_t threadCount;

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -1696,35 +1696,36 @@ class SnapshotPlaybackExecutor : public IVG::IVGExecutor {
 		const String &rawStatements = args.fetchRequired(0, false);
 
 		const bool hasLabel = (scenarioLabel != 0);
-		const bool blockTargetsScenario =
-			(scenario.explicitScenario
-				 ? (hasLabel && *scenarioLabel == scenario.name)
-				 : !hasLabel);
 
-		++nextBlockOrdinal;
+		const uint32_t blockOrdinal = ++nextBlockOrdinal;
 
 		const SnapshotInvocation *invocation = 0;
 		if (invocationCursor < entry.invocations.size()) {
 			const SnapshotInvocation &candidate =
 				entry.invocations[invocationCursor];
-			if (candidate.blockIndex == nextBlockOrdinal) {
+			if (candidate.blockIndex == blockOrdinal) {
 				invocation = &candidate;
 				++invocationCursor;
 			}
 		}
 
+		const bool blockTargetsScenario =
+			(scenario.explicitScenario
+				 ? (hasLabel && *scenarioLabel == scenario.name)
+				 : (!hasLabel && invocation != 0));
+
 		if (!blockTargetsScenario) {
 			args.throwIfAnyUnfetched();
 			if (invocation != 0) {
 				Interpreter::throwBadSyntax(
-					"unexpected snapshot invocation for scenario.");
+								"unexpected snapshot invocation for scenario.");
 			}
 			return true;
 		}
 
 		if (invocation == 0) {
 			Interpreter::throwBadSyntax(
-				"missing snapshot invocation for scenario block.");
+								"missing snapshot invocation for scenario block.");
 		}
 
 		if (blockValidate != entry.validate) {

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -387,12 +387,36 @@ static bool ensureDirectoryPath(const NuXFiles::Path &directory) {
 			return false;
 		}
 		for (std::vector<NuXFiles::Path>::reverse_iterator it =
-				 toCreate.rbegin();
+				toCreate.rbegin();
 			 it != toCreate.rend(); ++it) {
 			if (it->isRoot()) {
 				continue;
 			}
-			it->create();
+			try {
+				it->create();
+			} catch (const NuXFiles::Exception &) {
+				try {
+					if (it->exists() && it->isDirectory()) {
+						continue;
+					}
+				} catch (const NuXFiles::Exception &) {
+					return false;
+				} catch (const std::exception &) {
+					return false;
+				}
+				return false;
+			} catch (const std::exception &) {
+				try {
+					if (it->exists() && it->isDirectory()) {
+						continue;
+					}
+				} catch (const NuXFiles::Exception &) {
+					return false;
+				} catch (const std::exception &) {
+					return false;
+				}
+				return false;
+			}
 		}
 		return directory.exists() && directory.isDirectory();
 	} catch (const NuXFiles::Exception &) {


### PR DESCRIPTION
## Summary
- ensure the snapshot playback executor only targets implicit blocks when an invocation exists so multiple `meta snapshot` blocks replay correctly

## Testing
- timeout 600 ./build.sh *(fails: timed out at 600s)*

------
https://chatgpt.com/codex/tasks/task_e_68ea4af86004833294d4a87a79203b15