### PR TITLE
Update IVGSnapshot snapshot output handling

### DIFF
--- a/docs/IVGSnapshot Plan.md
+++ b/docs/IVGSnapshot Plan.md
@@ -166,7 +166,7 @@ void renderPlan(const SnapshotPlan& plan);
 - Parallelisation is postponed: once NuXThreads scheduling lands, `renderPlan` will enqueue `renderEntry` calls on the worker pool instead of running them inline.
 
 ## Golden Lifecycle
-- Goldens default to `<sanitized-source>__<scenario>.png` beside the IVG when `--snapshot-dir` is absent, where `sanitized-source` replaces directory separators and drive markers with underscores.
+- Goldens default to `<sanitized-source>__<scenario>.png` beside the IVG when `--snapshot-dir` is absent, where `sanitized-source` is the IVG path (without extension) relative to `--root-dir` (or the current working directory when omitted). Path separators map to a single `_` while existing underscores expand to `__` so nested IVGs produce unique flattened names.
 - Draft mode (`validate:no`) writes `<scenario>.png.disabled` and records success without comparison.
 - Validation mode requires an existing golden unless `--force-update` is supplied. When updating, the previous golden becomes `<scenario>.png.bak`.
 - Compare failures drop `<scenario>.actual.png` and `<scenario>.diff.png` alongside the golden to help debugging.

--- a/docs/IVGSnapshot Plan.md
+++ b/docs/IVGSnapshot Plan.md
@@ -166,7 +166,7 @@ void renderPlan(const SnapshotPlan& plan);
 - Parallelisation is postponed: once NuXThreads scheduling lands, `renderPlan` will enqueue `renderEntry` calls on the worker pool instead of running them inline.
 
 ## Golden Lifecycle
-- Goldens default to `<sanitized-source>__<scenario>.png` beside the IVG when `--snapshot-dir` is absent, where `sanitized-source` is the IVG path (without extension) relative to `--root-dir` (or the current working directory when omitted). Path separators map to a single `_` while existing underscores expand to `__` so nested IVGs produce unique flattened names.
+- Goldens default to `<sanitized-source>__<scenario>.png` beside the IVG when `--snapshot-dir` is absent, where `sanitized-source` is the IVG path (without extension) relative to `--root-dir` (or the current working directory when omitted). If the IVG sits outside that root we fall back to the absolute path. Path separators map to a single `_` while existing underscores expand to `__` so nested IVGs produce unique flattened names.
 - Draft mode (`validate:no`) writes `<scenario>.png.disabled` and records success without comparison.
 - Validation mode requires an existing golden unless `--force-update` is supplied. When updating, the previous golden becomes `<scenario>.png.bak`.
 - Compare failures drop `<scenario>.actual.png` and `<scenario>.diff.png` alongside the golden to help debugging.

--- a/docs/IVGSnapshot Plan.md
+++ b/docs/IVGSnapshot Plan.md
@@ -166,7 +166,7 @@ void renderPlan(const SnapshotPlan& plan);
 - Parallelisation is postponed: once NuXThreads scheduling lands, `renderPlan` will enqueue `renderEntry` calls on the worker pool instead of running them inline.
 
 ## Golden Lifecycle
-- Goldens default to `<basename>/<scenario>.png` beside the IVG when `--output-dir` is absent.
+- Goldens default to `<sanitized-source>__<scenario>.png` beside the IVG when `--snapshot-dir` is absent, where `sanitized-source` replaces directory separators and drive markers with underscores.
 - Draft mode (`validate:no`) writes `<scenario>.png.disabled` and records success without comparison.
 - Validation mode requires an existing golden unless `--force-update` is supplied. When updating, the previous golden becomes `<scenario>.png.bak`.
 - Compare failures drop `<scenario>.actual.png` and `<scenario>.diff.png` alongside the golden to help debugging.

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -363,8 +363,99 @@ static std::string sanitizeFileComponent(const std::string &name) {
 	return sanitized;
 }
 
+static bool tryBuildRelativeSnapshotTag(const NuXFiles::Path &rootDir,
+						const NuXFiles::Path &withoutExtension,
+						std::string &relative) {
+	if (rootDir.isNull()) {
+		return false;
+	}
+
+	std::wstring relativeWide;
+	try {
+		if (rootDir.makeRelative(withoutExtension, false, relativeWide)) {
+			if (!relativeWide.empty()) {
+				try {
+					relative = pathStringFromWide(relativeWide);
+				} catch (const std::exception &) {
+					relative.clear();
+					return false;
+				}
+				for (size_t i = 0; i < relative.size(); ++i) {
+					if (relative[i] == '\\') {
+						relative[i] = '/';
+					}
+				}
+				return true;
+			}
+		}
+	} catch (const NuXFiles::Exception &) {
+		relativeWide.clear();
+	} catch (const std::exception &) {
+		relativeWide.clear();
+	}
+
+	std::wstring rootWide;
+	std::wstring targetWide;
+	try {
+		rootWide = rootDir.getFullPath();
+		targetWide = withoutExtension.getFullPath();
+	} catch (const NuXFiles::Exception &) {
+		return false;
+	} catch (const std::exception &) {
+		return false;
+	}
+
+	if (rootWide.empty() || targetWide.empty()) {
+		return false;
+	}
+
+	std::wstring normalizedRoot;
+	try {
+		normalizedRoot = NuXFiles::Path::appendSeparator(rootWide);
+	} catch (const NuXFiles::Exception &) {
+		normalizedRoot = rootWide;
+	} catch (const std::exception &) {
+		normalizedRoot = rootWide;
+	}
+	if (!normalizedRoot.empty()) {
+		const wchar_t separator = NuXFiles::Path::getSeparator();
+		if (normalizedRoot[normalizedRoot.size() - 1] != separator) {
+			normalizedRoot.push_back(separator);
+		}
+	}
+
+	if (normalizedRoot.empty()) {
+		return false;
+	}
+	if (targetWide.size() <= normalizedRoot.size()) {
+		return false;
+	}
+	if (targetWide.compare(0, normalizedRoot.size(), normalizedRoot) != 0) {
+		return false;
+	}
+
+	const std::wstring remainder = targetWide.substr(normalizedRoot.size());
+	if (remainder.empty()) {
+		return false;
+	}
+
+	try {
+		relative = pathStringFromWide(remainder);
+	} catch (const std::exception &) {
+		return false;
+	}
+	for (size_t i = 0; i < relative.size(); ++i) {
+		if (relative[i] == '\\') {
+			relative[i] = '/';
+		}
+	}
+	return true;
+}
+
+
+
 static std::string buildSnapshotSourceTag(const std::string &ivgPath,
-										const NuXFiles::Path &rootDir) {
+						const NuXFiles::Path &rootDir) {
 	try {
 		const NuXFiles::Path sourcePath = pathFromNativeString(ivgPath);
 		if (!sourcePath.isNull()) {
@@ -377,43 +468,9 @@ static std::string buildSnapshotSourceTag(const std::string &ivgPath,
 				withoutExtension = sourcePath;
 			}
 
-                        std::wstring relativeWide;
-                        bool haveRelative = false;
-                        if (!rootDir.isNull()) {
-                                try {
-                                        if (rootDir.makeRelative(withoutExtension, false, relativeWide)) {
-                                                haveRelative = !relativeWide.empty();
-                                        }
-                                } catch (const NuXFiles::Exception &) {
-                                        relativeWide.clear();
-                                } catch (const std::exception &) {
-                                        relativeWide.clear();
-                                }
-                        }
-                        if (!haveRelative) {
-                                try {
-                                        relativeWide = withoutExtension.getFullPath();
-                                        haveRelative = !relativeWide.empty();
-                                } catch (const NuXFiles::Exception &) {
-                                        relativeWide.clear();
-                                } catch (const std::exception &) {
-                                        relativeWide.clear();
-                                }
-                        }
-
-                        if (haveRelative) {
-                                try {
-                                        std::string relative = pathStringFromWide(relativeWide);
-                                        if (!relative.empty()) {
-                                                for (size_t i = 0; i < relative.size(); ++i) {
-                                                        if (relative[i] == '\\') {
-								relative[i] = '/';
-							}
-						}
-						return sanitizeFileComponent(relative);
-					}
-				} catch (const std::exception &) {
-				}
+			std::string relative;
+			if (tryBuildRelativeSnapshotTag(rootDir, withoutExtension, relative)) {
+				return sanitizeFileComponent(relative);
 			}
 		}
 	} catch (const std::exception &) {
@@ -431,6 +488,8 @@ static std::string buildSnapshotSourceTag(const std::string &ivgPath,
 	}
 	return sanitizeFileComponent(normalized);
 }
+
+
 static std::string buildEntryIdentifier(const std::string &snapshotBase,
 										const SnapshotEntry &entry) {
 	const uint32_t blockIndex =

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -320,10 +320,17 @@ static std::string joinPath(const std::string &base,
 }
 
 static std::string sanitizeFileComponent(const std::string &name) {
-	std::string sanitized = name;
-	for (size_t i = 0; i < sanitized.size(); ++i) {
-		if (sanitized[i] == '/' || sanitized[i] == '\\' || sanitized[i] == ':') {
-			sanitized[i] = '_';
+	std::string sanitized;
+	sanitized.reserve(name.size() * 2);
+	for (size_t i = 0; i < name.size(); ++i) {
+		const char ch = name[i];
+		if (ch == '_') {
+			sanitized.push_back('_');
+			sanitized.push_back('_');
+		} else if (ch == '/' || ch == '\\' || ch == ':') {
+			sanitized.push_back('_');
+		} else {
+			sanitized.push_back(ch);
 		}
 	}
 	return sanitized;

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -377,35 +377,36 @@ static std::string buildSnapshotSourceTag(const std::string &ivgPath,
 				withoutExtension = sourcePath;
 			}
 
-			std::wstring relativeWide;
-			if (!rootDir.isNull()) {
-				try {
-					if (!rootDir.makeRelative(withoutExtension, true, relativeWide)
-						&& relativeWide.empty()) {
-						relativeWide = withoutExtension.getFullPath();
-					}
-				} catch (const NuXFiles::Exception &) {
-					relativeWide.clear();
-				} catch (const std::exception &) {
-					relativeWide.clear();
-				}
-			}
-			if (relativeWide.empty()) {
-				try {
-					relativeWide = withoutExtension.getFullPath();
-				} catch (const NuXFiles::Exception &) {
-					relativeWide.clear();
-				} catch (const std::exception &) {
-					relativeWide.clear();
-				}
-			}
+                        std::wstring relativeWide;
+                        bool haveRelative = false;
+                        if (!rootDir.isNull()) {
+                                try {
+                                        if (rootDir.makeRelative(withoutExtension, false, relativeWide)) {
+                                                haveRelative = !relativeWide.empty();
+                                        }
+                                } catch (const NuXFiles::Exception &) {
+                                        relativeWide.clear();
+                                } catch (const std::exception &) {
+                                        relativeWide.clear();
+                                }
+                        }
+                        if (!haveRelative) {
+                                try {
+                                        relativeWide = withoutExtension.getFullPath();
+                                        haveRelative = !relativeWide.empty();
+                                } catch (const NuXFiles::Exception &) {
+                                        relativeWide.clear();
+                                } catch (const std::exception &) {
+                                        relativeWide.clear();
+                                }
+                        }
 
-			if (!relativeWide.empty()) {
-				try {
-					std::string relative = pathStringFromWide(relativeWide);
-					if (!relative.empty()) {
-						for (size_t i = 0; i < relative.size(); ++i) {
-							if (relative[i] == '\\') {
+                        if (haveRelative) {
+                                try {
+                                        std::string relative = pathStringFromWide(relativeWide);
+                                        if (!relative.empty()) {
+                                                for (size_t i = 0; i < relative.size(); ++i) {
+                                                        if (relative[i] == '\\') {
 								relative[i] = '/';
 							}
 						}

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -245,6 +245,7 @@ struct CommandLineOptions {
 	std::vector<std::string> fontDirs;
 	std::vector<std::string> imageDirs;
 	std::string snapshotDir;
+	NuXFiles::Path rootDir;
 	bool forceUpdate;
 	bool listOnly;
 	bool verbose;
@@ -253,7 +254,8 @@ struct CommandLineOptions {
 	std::vector<std::string> ivgPaths;
 
 	CommandLineOptions()
-		: forceUpdate(false), listOnly(false), verbose(false),
+		: rootDir(NuXFiles::Path::getCurrentDirectoryPath()),
+		  forceUpdate(false), listOnly(false), verbose(false),
 		  exitOnFirstFailure(false), threads(0) {}
 };
 
@@ -262,9 +264,9 @@ static std::string stringFromIMPD(const String &value) {
 }
 
 static std::wstring pathStringToWide(const std::string &path) {
-	if (path.empty()) {
-		return std::wstring();
-	}
+        if (path.empty()) {
+                return std::wstring();
+        }
 #if defined(_WIN32)
 	const int sourceLength = static_cast<int>(path.size());
 	const int wideLength =
@@ -281,15 +283,40 @@ static std::wstring pathStringToWide(const std::string &path) {
 	return wide;
 #else
 	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
-	return converter.from_bytes(path);
+        return converter.from_bytes(path);
 #endif
 }
 
-static NuXFiles::Path pathFromNativeString(const std::string &path) {
+static std::string pathStringFromWide(const std::wstring &path) {
 	if (path.empty()) {
-		return NuXFiles::Path();
+		return std::string();
 	}
-	try {
+#if defined(_WIN32)
+	const int sourceLength = static_cast<int>(path.size());
+	const int narrowLength =
+			::WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, path.data(), sourceLength,
+							0, 0, 0, 0);
+	if (narrowLength <= 0) {
+		throw std::range_error("failed to convert wide path to native characters");
+	}
+	std::string narrow(static_cast<size_t>(narrowLength), '\0');
+	const int converted =
+			::WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, path.data(), sourceLength,
+							&narrow[0], narrowLength, 0, 0);
+	if (converted != narrowLength) {
+		throw std::range_error("failed to convert wide path to native characters");
+	}
+	return narrow;
+#else
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+	return converter.to_bytes(path);
+#endif
+}
+static NuXFiles::Path pathFromNativeString(const std::string &path) {
+        if (path.empty()) {
+                return NuXFiles::Path();
+        }
+        try {
 		return NuXFiles::Path(pathStringToWide(path));
 	} catch (const std::range_error &) {
 		return NuXFiles::Path();
@@ -336,7 +363,61 @@ static std::string sanitizeFileComponent(const std::string &name) {
 	return sanitized;
 }
 
-static std::string buildSnapshotSourceTag(const std::string &ivgPath) {
+static std::string buildSnapshotSourceTag(const std::string &ivgPath,
+										const NuXFiles::Path &rootDir) {
+	try {
+		const NuXFiles::Path sourcePath = pathFromNativeString(ivgPath);
+		if (!sourcePath.isNull()) {
+			NuXFiles::Path withoutExtension(sourcePath);
+			try {
+				withoutExtension = sourcePath.withoutExtension();
+			} catch (const NuXFiles::Exception &) {
+				withoutExtension = sourcePath;
+			} catch (const std::exception &) {
+				withoutExtension = sourcePath;
+			}
+
+			std::wstring relativeWide;
+			if (!rootDir.isNull()) {
+				try {
+					if (!rootDir.makeRelative(withoutExtension, true, relativeWide)
+						&& relativeWide.empty()) {
+						relativeWide = withoutExtension.getFullPath();
+					}
+				} catch (const NuXFiles::Exception &) {
+					relativeWide.clear();
+				} catch (const std::exception &) {
+					relativeWide.clear();
+				}
+			}
+			if (relativeWide.empty()) {
+				try {
+					relativeWide = withoutExtension.getFullPath();
+				} catch (const NuXFiles::Exception &) {
+					relativeWide.clear();
+				} catch (const std::exception &) {
+					relativeWide.clear();
+				}
+			}
+
+			if (!relativeWide.empty()) {
+				try {
+					std::string relative = pathStringFromWide(relativeWide);
+					if (!relative.empty()) {
+						for (size_t i = 0; i < relative.size(); ++i) {
+							if (relative[i] == '\\') {
+								relative[i] = '/';
+							}
+						}
+						return sanitizeFileComponent(relative);
+					}
+				} catch (const std::exception &) {
+				}
+			}
+		}
+	} catch (const std::exception &) {
+	}
+
 	std::string normalized = ivgPath;
 	for (size_t i = 0; i < normalized.size(); ++i) {
 		if (normalized[i] == '\\') {
@@ -349,7 +430,6 @@ static std::string buildSnapshotSourceTag(const std::string &ivgPath) {
 	}
 	return sanitizeFileComponent(normalized);
 }
-
 static std::string buildEntryIdentifier(const std::string &snapshotBase,
 										const SnapshotEntry &entry) {
 	const uint32_t blockIndex =
@@ -768,21 +848,20 @@ class SnapshotGolden {
 	SnapshotGolden(const std::string &ivgPath, const std::string &snapshotBase,
 	                           const SnapshotScenario &scenario, const SnapshotEntry &entry,
 	                           const CommandLineOptions &options) {
-		const std::string sanitizedBase = sanitizeFileComponent(snapshotBase);
-		const std::string root =
-			(options.snapshotDir.empty() ? extractDirectory(ivgPath)
-			                                           : options.snapshotDir);
-		std::string scenarioName = stringFromIMPD(entry.scenarioName);
-		if (scenario.entryIndices.size() > 1) {
+                const std::string root =
+                        (options.snapshotDir.empty() ? extractDirectory(ivgPath)
+                                                                   : options.snapshotDir);
+                std::string scenarioName = stringFromIMPD(entry.scenarioName);
+                if (scenario.entryIndices.size() > 1) {
 			scenarioName += "-";
 			scenarioName +=
 				Interpreter::toString(static_cast<int32_t>(entry.entryOrdinal));
-		}
-		scenarioName = sanitizeFileComponent(scenarioName);
-		std::string fileStem = scenarioName;
-		if (!sanitizedBase.empty()) {
-			fileStem = sanitizedBase + "__" + fileStem;
-		}
+                }
+                scenarioName = sanitizeFileComponent(scenarioName);
+                std::string fileStem = scenarioName;
+                if (!snapshotBase.empty()) {
+                        fileStem = snapshotBase + "__" + fileStem;
+                }
 		const std::string stem = joinPath(root, fileStem);
 		goldenPath = stem + ".png";
 		oldPath = stem + ".png.old";
@@ -2069,6 +2148,8 @@ static void printUsage(const char *program) {
 	std::cout << "\t--image-dir <path>\tAdd image search path." << std::endl;
 	std::cout << "\t--snapshot-dir <path>\tOverride snapshot directory."
 			  << std::endl;
+	std::cout << "\t--root-dir <path>\t\tRoot for snapshot name generation."
+			  << std::endl;
 	std::cout << "\t--force-update\t\tOverwrite goldens." << std::endl;
 	std::cout << "\t--threads <n>\t\tNumber of worker threads." << std::endl;
 	std::cout << "\t--list-only\t\tList collected snapshots without rendering."
@@ -2078,7 +2159,6 @@ static void printUsage(const char *program) {
 			  << std::endl;
 	std::cout << "\t--help\t\t\tShow this message." << std::endl;
 }
-
 static bool parseUnsigned(const std::string &text, uint32_t &value) {
 	if (text.empty()) {
 		return false;
@@ -2130,6 +2210,18 @@ static bool parseCommandLine(int argc, char **argv,
 				return false;
 			}
 			options.snapshotDir = argv[++i];
+		} else if (arg == "--root-dir") {
+			if (i + 1 >= argc) {
+				std::cerr << "--root-dir requires a path." << std::endl;
+				return false;
+			}
+			const std::string rootArgument(argv[++i]);
+			options.rootDir = pathFromNativeString(rootArgument);
+			if (options.rootDir.isNull()) {
+				std::cerr << "failed to parse root directory: " << rootArgument
+						<< std::endl;
+				return false;
+			}
 		} else if (arg == "--force-update") {
 			options.forceUpdate = true;
 		} else if (arg == "--threads") {
@@ -2525,13 +2617,13 @@ static void flushSchedulerResults(SnapshotScheduler &scheduler, bool wait,
 	}
 }
 static SnapshotRunResult renderPlan(const CommandLineOptions &options,
-									const std::string &path,
-									const CachedDocument &document,
-									const SnapshotPlan &plan) {
-	SnapshotRunResult run;
-	const std::vector<SnapshotScenario> &scenarios = plan.getScenarios();
-	const std::vector<SnapshotEntry> &entries = plan.getEntries();
-	const std::string snapshotBase = buildSnapshotSourceTag(path);
+                                                                        const std::string &path,
+                                                                        const CachedDocument &document,
+                                                                        const SnapshotPlan &plan) {
+        SnapshotRunResult run;
+        const std::vector<SnapshotScenario> &scenarios = plan.getScenarios();
+        const std::vector<SnapshotEntry> &entries = plan.getEntries();
+        const std::string snapshotBase = buildSnapshotSourceTag(path, options.rootDir);
 	SharedResources sharedResources;
 
 	uint32_t threadCount = options.threads;

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -244,7 +244,7 @@ struct CommandLineOptions {
 	std::vector<std::string> includeDirs;
 	std::vector<std::string> fontDirs;
 	std::vector<std::string> imageDirs;
-	std::string outputDir;
+	std::string snapshotDir;
 	bool forceUpdate;
 	bool listOnly;
 	bool verbose;
@@ -322,20 +322,34 @@ static std::string joinPath(const std::string &base,
 static std::string sanitizeFileComponent(const std::string &name) {
 	std::string sanitized = name;
 	for (size_t i = 0; i < sanitized.size(); ++i) {
-		if (sanitized[i] == '/' || sanitized[i] == '\\') {
+		if (sanitized[i] == '/' || sanitized[i] == '\\' || sanitized[i] == ':') {
 			sanitized[i] = '_';
 		}
 	}
 	return sanitized;
 }
 
-static std::string buildEntryIdentifier(const std::string &baseName,
+static std::string buildSnapshotSourceTag(const std::string &ivgPath) {
+	std::string normalized = ivgPath;
+	for (size_t i = 0; i < normalized.size(); ++i) {
+		if (normalized[i] == '\\') {
+			normalized[i] = '/';
+		}
+	}
+	const size_t dot = normalized.find_last_of('.');
+	if (dot != std::string::npos) {
+		normalized.resize(dot);
+	}
+	return sanitizeFileComponent(normalized);
+}
+
+static std::string buildEntryIdentifier(const std::string &snapshotBase,
 										const SnapshotEntry &entry) {
 	const uint32_t blockIndex =
 		(entry.invocations.empty() ? 0 : entry.invocations[0].blockIndex);
 	std::ostringstream stream;
-	stream << baseName << '#' << stringFromIMPD(entry.scenarioName) << '#'
-		   << blockIndex << '#' << entry.entryOrdinal;
+	stream << snapshotBase << '#' << stringFromIMPD(entry.scenarioName) << '#'
+			<< blockIndex << '#' << entry.entryOrdinal;
 	return stream.str();
 }
 
@@ -738,22 +752,19 @@ static bool writeRasterToPng(
 	std::string &error);
 static SnapshotEntryResult
 renderEntry(const CommandLineOptions &options, const std::string &path,
-			const std::string &baseName, const CachedDocument &document,
-			SharedResources &sharedResources, const SnapshotScenario &scenario,
-			const SnapshotEntry &entry);
+		const std::string &snapshotBase, const CachedDocument &document,
+		SharedResources &sharedResources, const SnapshotScenario &scenario,
+		const SnapshotEntry &entry);
 
 class SnapshotGolden {
   public:
-	SnapshotGolden(const std::string &ivgPath, const std::string &baseName,
-				   const SnapshotScenario &scenario, const SnapshotEntry &entry,
-				   const CommandLineOptions &options) {
-		const std::string sanitizedBase = sanitizeFileComponent(baseName);
-		std::string root =
-			(options.outputDir.empty() ? extractDirectory(ivgPath)
-									   : options.outputDir);
-		if (!sanitizedBase.empty()) {
-			root = joinPath(root, sanitizedBase);
-		}
+	SnapshotGolden(const std::string &ivgPath, const std::string &snapshotBase,
+	                           const SnapshotScenario &scenario, const SnapshotEntry &entry,
+	                           const CommandLineOptions &options) {
+		const std::string sanitizedBase = sanitizeFileComponent(snapshotBase);
+		const std::string root =
+			(options.snapshotDir.empty() ? extractDirectory(ivgPath)
+			                                           : options.snapshotDir);
 		std::string scenarioName = stringFromIMPD(entry.scenarioName);
 		if (scenario.entryIndices.size() > 1) {
 			scenarioName += "-";
@@ -761,7 +772,11 @@ class SnapshotGolden {
 				Interpreter::toString(static_cast<int32_t>(entry.entryOrdinal));
 		}
 		scenarioName = sanitizeFileComponent(scenarioName);
-		const std::string stem = joinPath(root, scenarioName);
+		std::string fileStem = scenarioName;
+		if (!sanitizedBase.empty()) {
+			fileStem = sanitizedBase + "__" + fileStem;
+		}
+		const std::string stem = joinPath(root, fileStem);
 		goldenPath = stem + ".png";
 		oldPath = stem + ".png.old";
 		actualPath = stem + ".actual.png";
@@ -2045,7 +2060,7 @@ static void printUsage(const char *program) {
 			  << std::endl;
 	std::cout << "\t--font-dir <path>\tAdd font search path." << std::endl;
 	std::cout << "\t--image-dir <path>\tAdd image search path." << std::endl;
-	std::cout << "\t--output-dir <path>\tOverride output directory."
+	std::cout << "\t--snapshot-dir <path>\tOverride snapshot directory."
 			  << std::endl;
 	std::cout << "\t--force-update\t\tOverwrite goldens." << std::endl;
 	std::cout << "\t--threads <n>\t\tNumber of worker threads." << std::endl;
@@ -2102,12 +2117,12 @@ static bool parseCommandLine(int argc, char **argv,
 				return false;
 			}
 			options.imageDirs.push_back(argv[++i]);
-		} else if (arg == "--output-dir") {
+		} else if (arg == "--snapshot-dir") {
 			if (i + 1 >= argc) {
-				std::cerr << "--output-dir requires a path." << std::endl;
+				std::cerr << "--snapshot-dir requires a path." << std::endl;
 				return false;
 			}
-			options.outputDir = argv[++i];
+			options.snapshotDir = argv[++i];
 		} else if (arg == "--force-update") {
 			options.forceUpdate = true;
 		} else if (arg == "--threads") {
@@ -2138,7 +2153,11 @@ static bool parseCommandLine(int argc, char **argv,
 	}
 
 	if (options.ivgPaths.empty()) {
-		std::cerr << "no IVG files specified." << std::endl;
+		if (argc <= 1) {
+			printUsage(argv[0]);
+		} else {
+			std::cerr << "no IVG files specified." << std::endl;
+		}
 		return false;
 	}
 	return true;
@@ -2186,12 +2205,12 @@ static void printPlan(const std::string &path, const SnapshotPlan &plan) {
 }
 struct SnapshotJob {
 	SnapshotJob()
-		: options(0), ivgPath(0), baseName(0), document(0), sharedResources(0),
+		: options(0), ivgPath(0), snapshotBase(0), document(0), sharedResources(0),
 		  scenario(0), entry(0), planOrdinal(0), sentinel(false) {}
 
 	const CommandLineOptions *options;
 	const std::string *ivgPath;
-	const std::string *baseName;
+	const std::string *snapshotBase;
 	const CachedDocument *document;
 	SharedResources *sharedResources;
 	const SnapshotScenario *scenario;
@@ -2317,7 +2336,7 @@ class SnapshotScheduler {
 			}
 
 			SnapshotEntryResult result = renderEntry(
-				*job.options, *job.ivgPath, *job.baseName, *job.document,
+				*job.options, *job.ivgPath, *job.snapshotBase, *job.document,
 				*job.sharedResources, *job.scenario, *job.entry);
 			result.planOrdinal = job.planOrdinal;
 			submitResult(result);
@@ -2384,7 +2403,7 @@ class SnapshotScheduler {
 };
 static SnapshotEntryResult
 renderEntry(const CommandLineOptions &options, const std::string &path,
-			const std::string &baseName, const CachedDocument &document,
+			const std::string &snapshotBase, const CachedDocument &document,
 			SharedResources &sharedResources, const SnapshotScenario &scenario,
 			const SnapshotEntry &entry) {
 	SnapshotEntryResult result;
@@ -2394,7 +2413,7 @@ renderEntry(const CommandLineOptions &options, const std::string &path,
 	result.validate = entry.validate;
 	result.blockIndex =
 		(entry.invocations.empty() ? 0 : entry.invocations[0].blockIndex);
-	result.identifier = buildEntryIdentifier(baseName, entry);
+		result.identifier = buildEntryIdentifier(snapshotBase, entry);
 
 	IVG::SelfContainedARGB32Canvas canvas;
 	SnapshotPlaybackExecutor executor(canvas, scenario, entry, options, path,
@@ -2435,7 +2454,7 @@ renderEntry(const CommandLineOptions &options, const std::string &path,
 		return result;
 	}
 
-	SnapshotGolden golden(path, baseName, scenario, entry, options);
+		SnapshotGolden golden(path, snapshotBase, scenario, entry, options);
 	if (!entry.validate) {
 		if (!golden.writeDraft(*raster, result)) {
 			if (result.message.empty()) {
@@ -2505,7 +2524,7 @@ static SnapshotRunResult renderPlan(const CommandLineOptions &options,
 	SnapshotRunResult run;
 	const std::vector<SnapshotScenario> &scenarios = plan.getScenarios();
 	const std::vector<SnapshotEntry> &entries = plan.getEntries();
-	const std::string baseName = stringFromIMPD(plan.getBaseName());
+	const std::string snapshotBase = buildSnapshotSourceTag(path);
 	SharedResources sharedResources;
 
 	uint32_t threadCount = options.threads;
@@ -2553,7 +2572,7 @@ static SnapshotRunResult renderPlan(const CommandLineOptions &options,
 			SnapshotJob job;
 			job.options = &options;
 			job.ivgPath = &path;
-			job.baseName = &baseName;
+			job.snapshotBase = &snapshotBase;
 			job.document = &document;
 			job.sharedResources = &sharedResources;
 			job.scenario = &scenario;

--- a/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
+++ b/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
@@ -204,7 +204,7 @@ namespace {
 			const std::string tempRoot = (tempEnv != 0 && tempEnv[0] != '\0') ? std::string(tempEnv) : std::string("/tmp");
 
 			CommandLineOptions options;
-			options.outputDir = joinPath(tempRoot, "IVGSnapshotWorkflowTest");
+			options.snapshotDir = joinPath(tempRoot, "IVGSnapshotWorkflowTest");
 			options.forceUpdate = false;
 
 			SnapshotScenario scenario;

--- a/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
+++ b/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
@@ -150,126 +150,174 @@ namespace {
 		ExpectEqual(entryTwo.invocations[1].blockIndex, 2, "entry two second block index");
 	}
 
-	void TestDefaultScenarioNames()
-	{
-		const char* source =
+void TestDefaultScenarioNames()
+{
+	const char* source =
 		"meta snapshot [ [ first ], [ second ] ]\n"
 		"meta snapshot [ third ]\n";
-		SnapshotPlan plan = CollectPlan("implicit.ivg", source);
+	SnapshotPlan plan = CollectPlan("implicit.ivg", source);
 
-		const std::vector<SnapshotScenario>& scenarios = plan.getScenarios();
-		const std::vector<SnapshotEntry>& entries = plan.getEntries();
+	const std::vector<SnapshotScenario>& scenarios = plan.getScenarios();
+	const std::vector<SnapshotEntry>& entries = plan.getEntries();
 
-		ExpectEqual(static_cast<uint32_t>(scenarios.size()), 3, "scenario count");
-		ExpectEqual(static_cast<uint32_t>(entries.size()), 3, "entry count");
+	ExpectEqual(static_cast<uint32_t>(scenarios.size()), 3, "scenario count");
+	ExpectEqual(static_cast<uint32_t>(entries.size()), 3, "entry count");
 
-		ExpectEqual(scenarios[0].name, "implicit-1-1", "first implicit scenario name");
-		ExpectEqual(scenarios[1].name, "implicit-1-2", "second implicit scenario name");
-		ExpectEqual(scenarios[2].name, "implicit-2", "third implicit scenario name");
+	ExpectEqual(scenarios[0].name, "implicit-1-1", "first implicit scenario name");
+	ExpectEqual(scenarios[1].name, "implicit-1-2", "second implicit scenario name");
+	ExpectEqual(scenarios[2].name, "implicit-2", "third implicit scenario name");
 
-		ExpectEqual(entries[scenarios[0].entryIndices[0]].entryOrdinal, 1, "first implicit entry ordinal");
-		ExpectEqual(entries[scenarios[1].entryIndices[0]].entryOrdinal, 1, "second implicit entry ordinal");
-		ExpectEqual(entries[scenarios[2].entryIndices[0]].entryOrdinal, 1, "third implicit entry ordinal");
+	ExpectEqual(entries[scenarios[0].entryIndices[0]].entryOrdinal, 1, "first implicit entry ordinal");
+	ExpectEqual(entries[scenarios[1].entryIndices[0]].entryOrdinal, 1, "second implicit entry ordinal");
+	ExpectEqual(entries[scenarios[2].entryIndices[0]].entryOrdinal, 1, "third implicit entry ordinal");
+}
+
+
+
+void TestSnapshotSourceTags()
+{
+	const NuXFiles::Path root = NuXFiles::Path::getCurrentDirectoryPath();
+	std::wstring rootWide;
+	try {
+		rootWide = root.getFullPath();
+	} catch (const std::exception&) {
+		Fail("failed to read current directory path");
 	}
+	std::wstring ivgWide = NuXFiles::Path::appendSeparator(rootWide);
+	ivgWide += L"alpha_beta";
+	ivgWide = NuXFiles::Path::appendSeparator(ivgWide);
+	ivgWide += L"gamma_delta.ivg";
+	const std::string ivgPath = pathStringFromWide(ivgWide);
+	const std::string relativeTag = buildSnapshotSourceTag(ivgPath, root);
+	Expect(relativeTag == "alpha__beta_gamma__delta", "root relative snapshot tag should escape underscores");
 
-		void TestValidateMismatch()
-		{
-			const char* source =
-			"meta snapshot scenario:toggle validate:no [ [ draft ] ]\n"
-			"meta snapshot scenario:toggle [ [ validate ] ]\n";
-
-			String textSource(source);
-			SnapshotPlan plan("mismatch.ivg");
-			std::vector<std::string> includeDirs;
-			SnapshotCollector collector(plan, "mismatch.ivg", textSource, includeDirs);
-			STLMapVariables variables;
-			FormatInfo formatInfo;
-			formatInfo.formatId = "meta";
-			formatInfo.uses.insert("snapshot-1");
-			Interpreter interpreter(collector, variables, formatInfo);
-
-			bool caught = false;
-			try {
-				interpreter.run(StringRange(textSource));
-			} catch (Exception& e) {
-				caught = true;
-				Expect(e.getError() == "scenario switches between validate yes/no.", "validate mismatch error message");
-			}
-			Expect(caught, "validate mismatch should throw");
+	NuXFiles::Path parent;
+	if (root.isRoot()) {
+		Fail("cannot run absolute tag test from filesystem root");
+	}
+	try {
+		parent = root.getParent();
+	} catch (const std::exception&) {
+		Fail("failed to resolve parent directory for absolute tag test");
+	}
+	std::wstring outsideWide = NuXFiles::Path::appendSeparator(parent.getFullPath());
+	outsideWide += L"absolute_example.ivg";
+	const std::string outsidePath = pathStringFromWide(outsideWide);
+	const std::string absoluteTag = buildSnapshotSourceTag(outsidePath, root);
+	std::string normalized = outsidePath;
+	for (size_t i = 0; i < normalized.size(); ++i) {
+		if (normalized[i] == '\\') {
+			normalized[i] = '/';
 		}
+	}
+	const size_t dot = normalized.find_last_of('.');
+	if (dot != std::string::npos) {
+		normalized.resize(dot);
+	}
+	Expect(absoluteTag == sanitizeFileComponent(normalized), "outside root should sanitize absolute path");
+}
 
-		void TestDraftValidateWorkflow()
-		{
-			const char* tempEnv = std::getenv("TMPDIR");
-			const std::string tempRoot = (tempEnv != 0 && tempEnv[0] != '\0') ? std::string(tempEnv) : std::string("/tmp");
 
-			CommandLineOptions options;
-			options.snapshotDir = joinPath(tempRoot, "IVGSnapshotWorkflowTest");
-			options.forceUpdate = false;
 
-			SnapshotScenario scenario;
-			scenario.name = "workflow";
-			scenario.validate = true;
-			scenario.entryIndices.push_back(0);
+void TestValidateMismatch()
+{
+	const char* source =
+		"meta snapshot scenario:toggle validate:no [ [ draft ] ]\n"
+		"meta snapshot scenario:toggle [ [ validate ] ]\n";
 
-			SnapshotEntry entry;
-			entry.scenarioIndex = 0;
-			entry.entryOrdinal = 1;
-			entry.validate = true;
-			entry.scenarioName = "workflow";
+	String textSource(source);
+	SnapshotPlan plan("mismatch.ivg");
+	std::vector<std::string> includeDirs;
+	SnapshotCollector collector(plan, "mismatch.ivg", textSource, includeDirs);
+	STLMapVariables variables;
+	FormatInfo formatInfo;
+	formatInfo.formatId = "meta";
+	formatInfo.uses.insert("snapshot-1");
+	Interpreter interpreter(collector, variables, formatInfo);
 
-			SnapshotGolden golden("workflow.ivg", "workflow", scenario, entry, options);
+	bool caught = false;
+	try {
+		interpreter.run(StringRange(textSource));
+	} catch (Exception& e) {
+		caught = true;
+		Expect(e.getError() == "scenario switches between validate yes/no.", "validate mismatch error message");
+	}
+	Expect(caught, "validate mismatch should throw");
+}
 
-			SnapshotEntryResult paths;
-			golden.populateResult(paths);
-			Expect(ensureDirectory(extractDirectory(paths.goldenPath)), "create workflow directory");
-			removeFileIfExists(paths.goldenPath);
-			removeFileIfExists(paths.oldPath);
-			removeFileIfExists(paths.actualPath);
-			removeFileIfExists(paths.diffPath);
-			removeFileIfExists(paths.backupPath);
+void TestDraftValidateWorkflow()
+{
+	const char* tempEnv = std::getenv("TMPDIR");
+	const std::string tempRoot = (tempEnv != 0 && tempEnv[0] != '\0') ? std::string(tempEnv) : std::string("/tmp");
 
-			NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> raster(NuXPixels::IntRect(0, 0, 1, 1));
-			raster.getPixelPointer()[0] = 0xFFFFFFFFu;
+	CommandLineOptions options;
+	options.snapshotDir = joinPath(tempRoot, "IVGSnapshotWorkflowTest");
+	options.forceUpdate = false;
 
-			SnapshotEntryResult draftResult;
-			Expect(golden.writeDraft(raster, draftResult), "draft write should succeed");
-			Expect(draftResult.success, "draft result success flag");
-			Expect(draftResult.skipped, "draft result skipped flag");
-			Expect(fileExists(draftResult.oldPath), "old draft file should exist");
-			Expect(!fileExists(draftResult.goldenPath), "golden should not exist after draft");
+	SnapshotScenario scenario;
+	scenario.name = "workflow";
+	scenario.validate = true;
+	scenario.entryIndices.push_back(0);
 
-			SnapshotEntryResult validateResult;
-			Expect(golden.validate(raster, false, validateResult), "validate should promote draft");
-			Expect(validateResult.success, "validate result success flag");
-			Expect(validateResult.updated, "validate should mark updated");
-			Expect(!validateResult.skipped, "validate should not be skipped");
-			Expect(fileExists(validateResult.goldenPath), "golden should exist after validate");
-			Expect(!fileExists(validateResult.oldPath), "old draft file should be removed");
-			Expect(validateResult.message.find("promoted draft image") != std::string::npos, "validate should report promotion");
+	SnapshotEntry entry;
+	entry.scenarioIndex = 0;
+	entry.entryOrdinal = 1;
+	entry.validate = true;
+	entry.scenarioName = "workflow";
 
-			SnapshotEntryResult secondResult;
-			Expect(golden.validate(raster, false, secondResult), "second validate should compare against golden");
-			Expect(secondResult.success, "second validate success flag");
-			Expect(!secondResult.updated, "second validate should not mark updated");
-			Expect(!secondResult.diffed, "second validate should not diff");
-			Expect(secondResult.message.empty(), "second validate should not report message");
+	SnapshotGolden golden("workflow.ivg", "workflow", scenario, entry, options);
 
-			removeFileIfExists(secondResult.goldenPath);
-			removeFileIfExists(secondResult.actualPath);
-			removeFileIfExists(secondResult.diffPath);
-			removeFileIfExists(secondResult.backupPath);
-			removeFileIfExists(paths.oldPath);
-		}
+	SnapshotEntryResult paths;
+	golden.populateResult(paths);
+	Expect(ensureDirectory(extractDirectory(paths.goldenPath)), "create workflow directory");
+	removeFileIfExists(paths.goldenPath);
+	removeFileIfExists(paths.oldPath);
+	removeFileIfExists(paths.actualPath);
+	removeFileIfExists(paths.diffPath);
+	removeFileIfExists(paths.backupPath);
+
+	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> raster(NuXPixels::IntRect(0, 0, 1, 1));
+	raster.getPixelPointer()[0] = 0xFFFFFFFFu;
+
+	SnapshotEntryResult draftResult;
+	Expect(golden.writeDraft(raster, draftResult), "draft write should succeed");
+	Expect(draftResult.success, "draft result success flag");
+	Expect(draftResult.skipped, "draft result skipped flag");
+	Expect(fileExists(draftResult.oldPath), "old draft file should exist");
+	Expect(!fileExists(draftResult.goldenPath), "golden should not exist after draft");
+
+	SnapshotEntryResult validateResult;
+	Expect(golden.validate(raster, false, validateResult), "validate should promote draft");
+	Expect(validateResult.success, "validate result success flag");
+	Expect(validateResult.updated, "validate should mark updated");
+	Expect(!validateResult.skipped, "validate should not be skipped");
+	Expect(fileExists(validateResult.goldenPath), "golden should exist after validate");
+	Expect(!fileExists(validateResult.oldPath), "old draft file should be removed");
+	Expect(validateResult.message.find("promoted draft image") != std::string::npos, "validate should report promotion");
+
+	SnapshotEntryResult secondResult;
+	Expect(golden.validate(raster, false, secondResult), "second validate should compare against golden");
+	Expect(secondResult.success, "second validate success flag");
+	Expect(!secondResult.updated, "second validate should not mark updated");
+	Expect(!secondResult.diffed, "second validate should not diff");
+	Expect(secondResult.message.empty(), "second validate should not report message");
+
+	removeFileIfExists(secondResult.goldenPath);
+	removeFileIfExists(secondResult.actualPath);
+	removeFileIfExists(secondResult.diffPath);
+	removeFileIfExists(secondResult.backupPath);
+	removeFileIfExists(paths.oldPath);
+}
 
 } // namespace
 
 int main()
-{
+	{
 	TestExplicitScenario();
 	TestArrayStatements();
 	TestRepeatedScenario();
 	TestDefaultScenarioNames();
+	TestSnapshotSourceTags();
 	TestValidateMismatch();
 	TestDraftValidateWorkflow();
 	return 0;

--- a/tools/IVGSnapshot/tests/WorkflowDraftValidate.sh
+++ b/tools/IVGSnapshot/tests/WorkflowDraftValidate.sh
@@ -30,28 +30,36 @@ SNAP
 output_dir="$temp_dir/snapshots"
 mkdir -p "$output_dir"
 
-run_draft="$("$snapshot_tool" --snapshot-dir "$output_dir" "$ivg_file")"
+run_draft="$("$snapshot_tool" --snapshot-dir "$output_dir" --root-dir "$temp_dir" "$ivg_file")"
 printf '%s\n' "$run_draft"
 
 snapshot_prefix="$(
-python3 - <<'PY' "$ivg_file"
+python3 - <<'PY' "$ivg_file" "$temp_dir"
+import os
 import sys
-path = sys.argv[1]
-path = path.replace("\\", "/")
-dot = path.rfind(".")
-if dot != -1:
-    path = path[:dot]
+from pathlib import Path
+
+ivg_path = Path(sys.argv[1]).with_suffix("")
+root_path = Path(sys.argv[2])
+
+try:
+    relative = ivg_path.relative_to(root_path)
+except ValueError:
+    relative = ivg_path
+
+path = str(relative).replace(os.sep, "/")
 result = []
 for ch in path:
     if ch == "_":
         result.append("__")
-    elif ch in "/:":
+    elif ch in "/\\:":
         result.append("_")
     else:
         result.append(ch)
+
 print("".join(result))
 PY
-)"
+ )"
 
 golden_path="$output_dir/${snapshot_prefix}__snaptest-1.png"
 old_path="$output_dir/${snapshot_prefix}__snaptest-1.png.old"
@@ -72,7 +80,7 @@ FILL $color
 ELLIPSE 15,15,14
 SNAP
 
-run_validate1="$("$snapshot_tool" --snapshot-dir "$output_dir" "$ivg_file")"
+run_validate1="$("$snapshot_tool" --snapshot-dir "$output_dir" --root-dir "$temp_dir" "$ivg_file")"
 printf '%s\n' "$run_validate1"
 
 if printf '%s\n' "$run_validate1" | grep -q "FAILED"; then
@@ -80,7 +88,7 @@ if printf '%s\n' "$run_validate1" | grep -q "FAILED"; then
 	exit 1
 fi
 
-run_validate2="$("$snapshot_tool" --snapshot-dir "$output_dir" "$ivg_file")"
+run_validate2="$("$snapshot_tool" --snapshot-dir "$output_dir" --root-dir "$temp_dir" "$ivg_file")"
 printf '%s\n' "$run_validate2"
 
 if printf '%s\n' "$run_validate2" | grep -q "FAILED"; then

--- a/tools/IVGSnapshot/tests/WorkflowDraftValidate.sh
+++ b/tools/IVGSnapshot/tests/WorkflowDraftValidate.sh
@@ -33,10 +33,25 @@ mkdir -p "$output_dir"
 run_draft="$("$snapshot_tool" --snapshot-dir "$output_dir" "$ivg_file")"
 printf '%s\n' "$run_draft"
 
-snapshot_prefix="${ivg_file%.*}"
-snapshot_prefix="${snapshot_prefix//\\/_}"
-snapshot_prefix="${snapshot_prefix//\//_}"
-snapshot_prefix="${snapshot_prefix//:/_}"
+snapshot_prefix="$(
+python3 - <<'PY' "$ivg_file"
+import sys
+path = sys.argv[1]
+path = path.replace("\\", "/")
+dot = path.rfind(".")
+if dot != -1:
+    path = path[:dot]
+result = []
+for ch in path:
+    if ch == "_":
+        result.append("__")
+    elif ch in "/:":
+        result.append("_")
+    else:
+        result.append(ch)
+print("".join(result))
+PY
+)"
 
 golden_path="$output_dir/${snapshot_prefix}__snaptest-1.png"
 old_path="$output_dir/${snapshot_prefix}__snaptest-1.png.old"

--- a/tools/IVGSnapshot/tests/WorkflowDraftValidate.sh
+++ b/tools/IVGSnapshot/tests/WorkflowDraftValidate.sh
@@ -30,11 +30,16 @@ SNAP
 output_dir="$temp_dir/snapshots"
 mkdir -p "$output_dir"
 
-run_draft="$("$snapshot_tool" --output-dir "$output_dir" "$ivg_file")"
+run_draft="$("$snapshot_tool" --snapshot-dir "$output_dir" "$ivg_file")"
 printf '%s\n' "$run_draft"
 
-golden_path="$output_dir/snaptest/snaptest-1.png"
-old_path="$output_dir/snaptest/snaptest-1.png.old"
+snapshot_prefix="${ivg_file%.*}"
+snapshot_prefix="${snapshot_prefix//\\/_}"
+snapshot_prefix="${snapshot_prefix//\//_}"
+snapshot_prefix="${snapshot_prefix//:/_}"
+
+golden_path="$output_dir/${snapshot_prefix}__snaptest-1.png"
+old_path="$output_dir/${snapshot_prefix}__snaptest-1.png.old"
 if [ ! -f "$old_path" ] && [ ! -f "$golden_path" ]; then
 	echo "Draft run did not produce a .png.old artifact." >&2
 	exit 1
@@ -52,7 +57,7 @@ FILL $color
 ELLIPSE 15,15,14
 SNAP
 
-run_validate1="$("$snapshot_tool" --output-dir "$output_dir" "$ivg_file")"
+run_validate1="$("$snapshot_tool" --snapshot-dir "$output_dir" "$ivg_file")"
 printf '%s\n' "$run_validate1"
 
 if printf '%s\n' "$run_validate1" | grep -q "FAILED"; then
@@ -60,7 +65,7 @@ if printf '%s\n' "$run_validate1" | grep -q "FAILED"; then
 	exit 1
 fi
 
-run_validate2="$("$snapshot_tool" --output-dir "$output_dir" "$ivg_file")"
+run_validate2="$("$snapshot_tool" --snapshot-dir "$output_dir" "$ivg_file")"
 printf '%s\n' "$run_validate2"
 
 if printf '%s\n' "$run_validate2" | grep -q "FAILED"; then


### PR DESCRIPTION
## Summary
- rename the IVGSnapshot output override option to `--snapshot-dir` and print the usage banner when no IVGs are supplied
- flatten snapshot filenames by prefixing sanitized source paths so nested IVGs no longer collide
- update the workflow test, plan test, and documentation to cover the new terminology and layout

## Testing
- `timeout 1800 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68eb942fe17c83328cfc55cbcf9849ba