### PR TITLE
Add scenario coverage tests for IVGSnapshot

### DIFF
--- a/tools/IVGSnapshot/tests/ListScenarioVariants.ivg
+++ b/tools/IVGSnapshot/tests/ListScenarioVariants.ivg
@@ -1,0 +1,8 @@
+format snapshot uses:[snapshot-1]
+meta snapshot scenario:alpha [ [ set fill red ], [ set stroke blue ] ]
+meta snapshot scenario:alpha [ [ set highlight gold ], [ set outline green ] ]
+meta snapshot validate:no [ set dash 4 ]
+meta snapshot [ [ set implicit-one ], [ set implicit-two ] ]
+meta snapshot [ set implicit-three ]
+meta snapshot scenario:beta validate:no [ set shadow black ]
+meta snapshot scenario:beta validate:no [ set shadow gray ]

--- a/tools/IVGSnapshot/tests/ListScenarioVariants.txt
+++ b/tools/IVGSnapshot/tests/ListScenarioVariants.txt
@@ -1,0 +1,47 @@
+tools/IVGSnapshot/tests/ListScenarioVariants.ivg
+	Scenario alpha (validate: yes)
+		Entry 1
+			Block 1 (statement 1), line 2
+				[  set fill red  ]
+			Block 2 (statement 1), line 3
+				[  set highlight gold  ]
+		Entry 2
+			Block 1 (statement 2), line 2
+				[  set stroke blue  ]
+			Block 2 (statement 2), line 3
+				[  set outline green  ]
+	Scenario ListScenarioVariants-3 (validate: no)
+		Entry 1
+			Block 3 (statement 1), line 4
+				[  set dash 4  ]
+	Scenario ListScenarioVariants-4-1 (validate: yes)
+		Entry 1
+			Block 4 (statement 1), line 5
+				[  set implicit-one  ]
+	Scenario ListScenarioVariants-4-2 (validate: yes)
+		Entry 1
+			Block 4 (statement 2), line 5
+				[  set implicit-two  ]
+	Scenario ListScenarioVariants-5 (validate: yes)
+		Entry 1
+			Block 5 (statement 1), line 6
+				[  set implicit-three  ]
+	Scenario beta (validate: no)
+		Entry 1
+			Block 6 (statement 1), line 7
+				[  set shadow black  ]
+			Block 7 (statement 1), line 8
+				[  set shadow gray  ]
+# tools/IVGSnapshot/tests/ListScenarioVariants.ivg
+
+Summary
+  Snapshots       : 7 total (5 validated)
+  Updated         : 0
+  Failed          : 0 (diff failures: 0)
+
+# Overall Summary
+
+  Processed files : 1 (0 failed)
+  Snapshots       : 7 total (5 validated)
+  Updated         : 0
+  Failed          : 0 (diff failures: 0)

--- a/tools/IVGSnapshot/tests/WorkflowDraftValidate.sh
+++ b/tools/IVGSnapshot/tests/WorkflowDraftValidate.sh
@@ -92,7 +92,67 @@ run_validate2="$("$snapshot_tool" --snapshot-dir "$output_dir" --root-dir "$temp
 printf '%s\n' "$run_validate2"
 
 if printf '%s\n' "$run_validate2" | grep -q "FAILED"; then
-	echo "Second validation run reported a failure." >&2
+        echo "Second validation run reported a failure." >&2
+        exit 1
+fi
+
+cat <<'SNAP' > "$ivg_file"
+format ivg-3 uses:snapshot-1
+bounds 0,0,37,37
+meta snapshot validate:no [
+        color=#E74C3C
+        highlight=#FFFFFF
+        shadow=#000000
+]
+FILL $color
+ELLIPSE 15,15,14
+SNAP
+
+run_disable="$("$snapshot_tool" --snapshot-dir "$output_dir" --root-dir "$temp_dir" "$ivg_file")"
+printf '%s\n' "$run_disable"
+
+if printf '%s\n' "$run_disable" | grep -q "FAILED"; then
+	echo "Disabling validation reported a failure." >&2
+	exit 1
+fi
+
+if [ ! -f "$old_path" ]; then
+	echo "Disabling validation did not regenerate the .png.old draft." >&2
+	exit 1
+fi
+
+if [ -f "$golden_path" ]; then
+	echo "Golden image was not removed when validation was disabled." >&2
+	exit 1
+fi
+
+cat <<'SNAP' > "$ivg_file"
+format ivg-3 uses:snapshot-1
+bounds 0,0,37,37
+meta snapshot validate:yes [
+        color=#E74C3C
+        highlight=#FFFFFF
+        shadow=#000000
+]
+FILL $color
+ELLIPSE 15,15,14
+SNAP
+
+run_reenable="$("$snapshot_tool" --snapshot-dir "$output_dir" --root-dir "$temp_dir" "$ivg_file")"
+printf '%s\n' "$run_reenable"
+
+if printf '%s\n' "$run_reenable" | grep -q "FAILED"; then
+	echo "Re-enabling validation reported a failure." >&2
+	exit 1
+fi
+
+if [ ! -f "$golden_path" ]; then
+	echo "Golden image was not restored after re-enabling validation." >&2
+	exit 1
+fi
+
+if [ -f "$old_path" ]; then
+	echo "Draft artifact still present after re-enabling validation." >&2
 	exit 1
 fi
 

--- a/tools/buildAndTest.sh
+++ b/tools/buildAndTest.sh
@@ -105,4 +105,8 @@ tmp=$(mktemp)
 ./output/IVGSnapshot --list-only tools/IVGSnapshot/tests/ListOnlySample.ivg > "$tmp"
 diff --strip-trailing-cr tools/IVGSnapshot/tests/ListOnlySample.txt "$tmp"
 rm "$tmp"
+tmp=$(mktemp)
+./output/IVGSnapshot --list-only tools/IVGSnapshot/tests/ListScenarioVariants.ivg > "$tmp"
+diff --strip-trailing-cr tools/IVGSnapshot/tests/ListScenarioVariants.txt "$tmp"
+rm "$tmp"
 exit 0


### PR DESCRIPTION
## Summary
- add a ListScenarioVariants fixture that exercises named, unnamed, repeated, and multi-entry snapshot scenarios
- record the expected --list-only output for the new fixture and include it in the automated diff check
- expand the workflow validation script to cover toggling validate flags from yes to no and back to yes

## Testing
- ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68ece696b178833289b0731b020fdb47