### PR TITLE
Fix extra closure in SnapshotController

### DIFF
--- a/tools/ivgfiddle/src/ivgfiddle.js
+++ b/tools/ivgfiddle/src/ivgfiddle.js
@@ -430,7 +430,6 @@ const SnapshotController = (function createSnapshotController() {
 		getSelectionForRender: getSelectionForRender,
 	};
 })();
-})();
 
 if (snapshotScenarioSelect !== null) {
 		snapshotScenarioSelect.addEventListener("change", function handleSnapshotChange() {


### PR DESCRIPTION
## Summary
- remove an extra IIFE closure terminator from the SnapshotController module so the fiddle script parses correctly

## Testing
- timeout 600 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68f006564ad0833298613c4e597962f8