### PR TITLE
Ensure snapshot toolbar resets and selection persists

### DIFF
--- a/docs/IVGSnapshot Iterative Execution Plan.md
+++ b/docs/IVGSnapshot Iterative Execution Plan.md
@@ -1,65 +1,64 @@
 IVGSnapshot: Iterative Single-Pass Execution Plan
 
 ## TODO Overview
-- [ ] Remove the separate “collect-then-playback” staging and run IVG files from the beginning each round, so variable state established by the renderer before a snapshot meta affects snapshot parsing and logic.
-- [ ] Execute the script end-to-end repeatedly (rounds). In each round, only the snapshots that match the round’s selected scenario + entry ordinal run; all other snapshots are observed but skipped. If any other snapshots are detected, schedule another round and repeat with the next selection. If no snapshots are encountered at all, render once and discard the image without treating the file as a failure.
+- [x] Remove the separate “collect-then-playback” staging and run IVG files from the beginning each round, so variable state established by the renderer before a snapshot meta affects snapshot parsing and logic.
+- [x] Execute the script end-to-end repeatedly (rounds). In each round, only the snapshots that match the round’s selected scenario + entry ordinal run; all other snapshots are observed but skipped. If any other snapshots are detected, schedule another round and repeat with the next selection. If no snapshots are encountered at all, render once and discard the image without treating the file as a failure.
 
 ## TODO Constraints
-- [ ] Preserve existing snapshot naming and golden file layout to avoid churn.
-- [ ] Continue supporting `validate:(yes|no)` and the new statement grammar:
-        - [ ] Single body via one positional argument
-        - [ ] Multiple bodies only via `list:[ [ ... ] [ ... ] ... ]`
-- [ ] Maintain `--list-only` output as a stable, deterministic list identical to previous semantics.
+- [x] Preserve existing snapshot naming and golden file layout to avoid churn.
+- [x] Continue supporting `validate:(yes|no)` and the new statement grammar:
+        - [x] Single body via one positional argument
+        - [x] Multiple bodies only via `list:[ [ ... ] [ ... ] ... ]`
+- [x] Maintain `--list-only` output as a stable, deterministic list identical to previous semantics.
 - [ ] Allow reduced per-file parallelism while keeping multi-file concurrency.
 
 ## TODO Terminology
-- [ ] Confirm scenario definitions via `scenario:<name>` or implicit generation.
-- [ ] Confirm entry ordinal as the 1-based index within each `list:` block (1 for single-body).
-- [ ] Confirm invocation meaning: one `meta snapshot` block occurrence in the source.
+- [x] Confirm scenario definitions via `scenario:<name>` or implicit generation.
+- [x] Confirm entry ordinal as the 1-based index within each `list:` block (1 for single-body).
+- [x] Confirm invocation meaning: one `meta snapshot` block occurrence in the source.
 
 ## TODO High-Level Design
-- [ ] Replace the plan-collection phase with an iterative runner that executes the source with a real `IVG::IVGExecutor` every time.
-- [ ] On the first encountered `meta snapshot` in a round, pin the round’s selection:
-        - [ ] Derive the pinned scenario from explicit `scenario:` or implicit naming (see Compatibility section).
-        - [ ] Derive the pinned entry ordinal from the statement ordinal within the `list:` (or 1 for single-body).
-- [ ] During the remainder of the round:
-        - [ ] Execute only snapshot invocations matching the pinned selection (same scenario and entry ordinal across subsequent blocks) and enforce consistent `validate:` flags.
-        - [ ] For other scenarios or entry ordinals, mark `moreRemaining = true` and skip them for the current round.
-- [ ] After the round finishes:
-        - [ ] If there was no pinned selection (no snapshots encountered), discard any image and mark file as successfully processed with 0 snapshots.
-        - [ ] If a snapshot was pinned, validate/write golden for that selection as today.
-        - [ ] If `moreRemaining` is set, schedule another round and select the next unseen snapshot in deterministic order (see Ordering).
-- [ ] Repeat rounds until no remaining snapshots are observed.
+- [x] Replace the plan-collection phase with an iterative runner that executes the source with a real `IVG::IVGExecutor` every time.
+- [x] On the first encountered `meta snapshot` in a round, pin the round’s selection:
+        - [x] Derive the pinned scenario from explicit `scenario:` or implicit naming (see Compatibility section).
+        - [x] Derive the pinned entry ordinal from the statement ordinal within the `list:` (or 1 for single-body).
+- [x] During the remainder of the round:
+        - [x] Execute only snapshot invocations matching the pinned selection (same scenario and entry ordinal across subsequent blocks) and enforce consistent `validate:` flags.
+        - [x] For other scenarios or entry ordinals, mark `moreRemaining = true` and skip them for the current round.
+- [x] After the round finishes:
+        - [x] If there was no pinned selection (no snapshots encountered), discard any image and mark file as successfully processed with 0 snapshots.
+        - [x] If a snapshot was pinned, validate/write golden for that selection as today.
+        - [x] If `moreRemaining` is set, schedule another round and select the next unseen snapshot in deterministic order (see Ordering).
+- [x] Repeat rounds until no remaining snapshots are observed.
 
-## TODO Ordering and Determinism
-- [ ] Maintain stable ordering to keep list-only output and golden filenames deterministic:
-        - [ ] Use first-seen scenario order based on source execution.
-        - [ ] Within each scenario, process entry ordinals in ascending order (1..N).
-- [ ] Maintain an ordered registry in memory per file during processing:
+- [x] Maintain stable ordering to keep list-only output and golden filenames deterministic:
+        - [x] Use first-seen scenario order based on source execution.
+        - [x] Within each scenario, process entry ordinals in ascending order (1..N).
+- [x] Maintain an ordered registry in memory per file during processing:
         - [x] Implement `struct SeenScenario { String name; bool explicitLabel; bool validate; uint32_t maxOrdinal; std::vector<bool> processed; }`.
         - [x] On observing a new scenario+ordinal, expand `maxOrdinal`/`processed`, pin if unprocessed and no current selection, otherwise mark `moreRemaining = true`.
 
 ## TODO Meta Semantics (Single-Runner)
-- [ ] Parse arguments using `ArgumentsContainer` on the live interpreter frame to respect variable-dependent expansions inside `list:`/blocks.
-- [ ] Apply statement parsing rules:
-        - [ ] When `list:` is present, expand the outer list (`expand()`), then `parseList()` into verbatim elements while keeping brackets and whitespace for each element.
-        - [ ] When no `list:` is present, fetch exactly one positional argument verbatim (`fetchRequired(0, false)`).
-- [ ] Apply selection rules:
-        - [ ] Let the first matching invocation pin `(scenario, entryOrdinal, validate)` for the round.
-        - [ ] For subsequent invocations:
-                - [ ] If same scenario and ordinal, parse statements, verify the selected element exists, and keep for ID generation/consistency.
-                - [ ] If same scenario but different ordinal, mark `moreRemaining = true` and skip.
-                - [ ] If different scenario, mark `moreRemaining = true` and skip.
-- [ ] Ensure scenario-wide `validate` flags remain consistent across blocks; report mismatches as round errors.
+- [x] Parse arguments using `ArgumentsContainer` on the live interpreter frame to respect variable-dependent expansions inside `list:`/blocks.
+- [x] Apply statement parsing rules:
+        - [x] When `list:` is present, expand the outer list (`expand()`), then `parseList()` into verbatim elements while keeping brackets and whitespace for each element.
+        - [x] When no `list:` is present, fetch exactly one positional argument verbatim (`fetchRequired(0, false)`).
+- [x] Apply selection rules:
+        - [x] Let the first matching invocation pin `(scenario, entryOrdinal, validate)` for the round.
+        - [x] For subsequent invocations:
+                - [x] If same scenario and ordinal, parse statements, verify the selected element exists, and keep for ID generation/consistency.
+                - [x] If same scenario but different ordinal, mark `moreRemaining = true` and skip.
+                - [x] If different scenario, mark `moreRemaining = true` and skip.
+- [x] Ensure scenario-wide `validate` flags remain consistent across blocks; report mismatches as round errors.
 
 ## TODO Compatibility: Scenario Names and Snapshot IDs
-- [ ] Preserve previous implicit naming to avoid golden churn:
-        - [ ] For single-body blocks without `scenario:`, use `implicit-<blockOrdinal>`.
-        - [ ] For `list:` blocks with K bodies without `scenario:`, use `implicit-<blockOrdinal>-<entryOrdinal>`.
-- [ ] Build entry identifiers as `<snapshotSourceTag>_<scenarioName>#<entryOrdinal>`.
+- [x] Preserve previous implicit naming to avoid golden churn:
+        - [x] For single-body blocks without `scenario:`, use `implicit-<blockOrdinal>`.
+        - [x] For `list:` blocks with K bodies without `scenario:`, use `implicit-<blockOrdinal>-<entryOrdinal>`.
+- [x] Build entry identifiers as `<snapshotSourceTag>_<scenarioName>#<entryOrdinal>`.
 
 ## TODO CLI Behavior
-- [ ] Execute rounds without writing/validating images for `--list-only`. After the final round, print a merged listing of scenarios and entries in deterministic order with first-seen line numbers.
+- [x] Execute rounds without writing/validating images for `--list-only`. After the final round, print a merged listing of scenarios and entries in deterministic order with first-seen line numbers.
 - [ ] Keep semantics for `--force-update`, `--threads`, `--verbose`, and `--exit-on-first-failure`, allowing per-file serial rounds but multi-file concurrency.
 
 ## TODO Error Handling
@@ -73,12 +72,11 @@ IVGSnapshot: Iterative Single-Pass Execution Plan
         - [x] Maintain ordered `vector<SeenScenario>` and `map<String, size_t>` for lookup.
         - [x] Provide methods to choose the next unprocessed `(scenario, ordinal)` and to mark processed.
 
-## TODO Implementation Steps
-- [ ] Delete the collection-only executor from IVGSnapshot:
-        - [ ] Remove `SnapshotCollector` and `SnapshotPlan` usage from the IVGSnapshot binary.
-        - [ ] Remove `TestSnapshotPlan` binary and associated tests; replace with new list-only fixtures.
-- [ ] Introduce `SnapshotRoundCoordinator` (or integrate into the main runner):
-        - [ ] Drive repeated execution rounds for a single file until all snapshots are processed.
+- [x] Delete the collection-only executor from IVGSnapshot:
+        - [x] Remove `SnapshotCollector` and `SnapshotPlan` usage from the IVGSnapshot binary.
+        - [x] Remove `TestSnapshotPlan` binary and associated tests; replace with new list-only fixtures.
+- [x] Introduce `SnapshotRoundCoordinator` (or integrate into the main runner):
+        - [x] Drive repeated execution rounds for a single file until all snapshots are processed.
         - [x] Maintain `SnapshotProgress` across rounds.
 - [x] Refactor `SnapshotPlaybackExecutor` to support pin/skip logic:
         - [x] Add `SnapshotRoundState* round` pointer.
@@ -93,21 +91,21 @@ IVGSnapshot: Iterative Single-Pass Execution Plan
         - [x] Otherwise, validate/write golden for the pinned selection as today.
         - [x] Record processed `(scenario, ordinal)` in `SnapshotProgress`.
         - [x] If `round->moreRemaining` or `SnapshotProgress` has another unprocessed entry, set the next target and loop again; otherwise break.
-- [ ] Update `--list-only` to run the same loop but never write/validate images, then print a synthesized plan from `SnapshotProgress` that mirrors current output (scenarios, entries, blocks/lines).
-- [ ] Keep shared caches (fonts/images) and PNG IO unchanged.
-- [ ] Preserve snapshot ID generation and directory layout, with `SnapshotGolden` receiving `(scenario, ordinal)` metadata on the fly instead of via a prebuilt plan.
+- [x] Update `--list-only` to run the same loop but never write/validate images, then print a synthesized plan from `SnapshotProgress` that mirrors current output (scenarios, entries, blocks/lines).
+- [x] Keep shared caches (fonts/images) and PNG IO unchanged.
+- [x] Preserve snapshot ID generation and directory layout, with `SnapshotGolden` receiving `(scenario, ordinal)` metadata on the fly instead of via a prebuilt plan.
 
 ## TODO Testing Plan
-- [ ] Replace `TestSnapshotPlan` with tests that:
-        - [ ] Verify `--list-only` output on existing fixtures matches the current expected text.
-        - [ ] Add a new fixture where snapshot `list:` contents depend on variables set before the meta to prove the single-runner model captures correct expansions.
-        - [ ] Validate that repeated blocks for the same scenario and ordinal are accepted while mismatched `validate:` flags are rejected.
+- [x] Replace `TestSnapshotPlan` with tests that:
+        - [x] Verify `--list-only` output on existing fixtures matches the current expected text.
+        - [x] Add a new fixture where snapshot `list:` contents depend on variables set before the meta to prove the single-runner model captures correct expansions.
+        - [x] Validate that repeated blocks for the same scenario and ordinal are accepted while mismatched `validate:` flags are rejected.
 
 ## TODO Migration Notes
-- [ ] Remove or rewrite:
-        - [ ] `tools/IVGSnapshot/tests/TestSnapshotPlan.cpp`
-        - [ ] Any references to `SnapshotPlan` in build scripts.
-- [ ] Add new `--list-only` expected outputs and ensure deterministic ordering.
+- [x] Remove or rewrite:
+        - [x] `tools/IVGSnapshot/tests/TestSnapshotPlan.cpp`
+        - [x] Any references to `SnapshotPlan` in build scripts.
+- [x] Add new `--list-only` expected outputs and ensure deterministic ordering.
 
 ## TODO Future Work (Optional)
 - [ ] Persist a per-file snapshot index to allow resuming after partial runs.

--- a/docs/IVGSnapshot Iterative Execution Plan.md
+++ b/docs/IVGSnapshot Iterative Execution Plan.md
@@ -62,8 +62,8 @@ IVGSnapshot: Iterative Single-Pass Execution Plan
 - [ ] Keep semantics for `--force-update`, `--threads`, `--verbose`, and `--exit-on-first-failure`, allowing per-file serial rounds but multi-file concurrency.
 
 ## TODO Error Handling
-- [ ] If no snapshots are pinned in a round but the script throws, treat it as non-fatal: discard the image and continue to the next file.
-- [ ] If a snapshot is pinned and rendering fails, record a failure for that specific entry.
+- [x] If no snapshots are pinned in a round but the script throws, treat it as non-fatal: discard the image and continue to the next file.
+- [x] If a snapshot is pinned and rendering fails, record a failure for that specific entry.
 
 ## TODO Data Structures (New or Changed)
 - [x] Define `SnapshotRoundState` (per round):

--- a/docs/IVGSnapshot Iterative Execution Plan.md
+++ b/docs/IVGSnapshot Iterative Execution Plan.md
@@ -10,7 +10,7 @@ IVGSnapshot: Iterative Single-Pass Execution Plan
         - [x] Single body via one positional argument
         - [x] Multiple bodies only via `list:[ [ ... ] [ ... ] ... ]`
 - [x] Maintain `--list-only` output as a stable, deterministic list identical to previous semantics.
-- [ ] Allow reduced per-file parallelism while keeping multi-file concurrency.
+- [x] Allow reduced per-file parallelism while keeping multi-file concurrency.
 
 ## TODO Terminology
 - [x] Confirm scenario definitions via `scenario:<name>` or implicit generation.
@@ -59,7 +59,7 @@ IVGSnapshot: Iterative Single-Pass Execution Plan
 
 ## TODO CLI Behavior
 - [x] Execute rounds without writing/validating images for `--list-only`. After the final round, print a merged listing of scenarios and entries in deterministic order with first-seen line numbers.
-- [ ] Keep semantics for `--force-update`, `--threads`, `--verbose`, and `--exit-on-first-failure`, allowing per-file serial rounds but multi-file concurrency.
+- [x] Keep semantics for `--force-update`, `--threads`, `--verbose`, and `--exit-on-first-failure`, allowing per-file serial rounds but multi-file concurrency.
 
 ## TODO Error Handling
 - [x] If no snapshots are pinned in a round but the script throws, treat it as non-fatal: discard the image and continue to the next file.

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -276,42 +276,44 @@ class SnapshotProgress {
 
 	bool empty() const { return seenScenarios.empty(); }
 
-	bool observeScenarioEntry(SnapshotRoundState &round,
-		const String &scenarioName,
-		bool explicitLabel, bool validate,
-		uint32_t entryOrdinal) {
-		if (entryOrdinal == 0) {
-			throw std::runtime_error("snapshot entry ordinal must be >= 1");
-		}
+        bool observeScenarioEntry(SnapshotRoundState &round,
+                const String &scenarioName,
+                bool explicitLabel, bool validate,
+                uint32_t entryOrdinal) {
+                if (entryOrdinal == 0) {
+                        throw std::runtime_error("snapshot entry ordinal must be >= 1");
+                }
 
-		SeenScenario &scenario = upsertScenarioRecord(scenarioName, explicitLabel,
-				validate);
-		scenario.ensureCapacity(entryOrdinal);
+                const uint32_t normalizedOrdinal = (explicitLabel ? entryOrdinal : 1);
 
-		const bool alreadyProcessed = scenario.isProcessed(entryOrdinal);
+                SeenScenario &scenario = upsertScenarioRecord(scenarioName, explicitLabel,
+                                validate);
+                scenario.ensureCapacity(normalizedOrdinal);
 
-		if (!round.hasPinned) {
-			if (!alreadyProcessed) {
-                                round.pin(scenarioName, entryOrdinal, validate,
+                const bool alreadyProcessed = scenario.isProcessed(normalizedOrdinal);
+
+                if (!round.hasPinned) {
+                        if (!alreadyProcessed) {
+                                round.pin(scenarioName, normalizedOrdinal, validate,
                                                 explicitLabel);
-				return true;
-			}
-			return false;
-		}
+                                return true;
+                        }
+                        return false;
+                }
 
-		if (!round.matchesSelection(scenarioName, entryOrdinal)) {
-			if (!alreadyProcessed) {
-				round.moreRemaining = true;
-			}
-			return false;
-		}
+                if (!round.matchesSelection(scenarioName, normalizedOrdinal)) {
+                        if (!alreadyProcessed) {
+                                round.moreRemaining = true;
+                        }
+                        return false;
+                }
 
-		if (round.validate != validate) {
-			throw std::runtime_error("validate flag mismatch for scenario");
-		}
+                if (round.validate != validate) {
+                        throw std::runtime_error("validate flag mismatch for scenario");
+                }
 
-		return !alreadyProcessed;
-	}
+                return !alreadyProcessed;
+        }
 
 	bool hasNextTarget() const {
 		if (hasPendingTarget) {
@@ -1996,6 +1998,8 @@ class SnapshotPlaybackExecutor : public IVG::IVGExecutor {
 
                 for (uint32_t i = 0; i < statements.size(); ++i) {
                         const uint32_t entryOrdinal = i + 1;
+                        const uint32_t scenarioOrdinal =
+                                (explicitLabel ? entryOrdinal : 1);
                         const String scenarioName =
                                 (explicitLabel
                                          ? *scenarioLabel
@@ -2006,8 +2010,8 @@ class SnapshotPlaybackExecutor : public IVG::IVGExecutor {
                                 *round, scenarioName, explicitLabel, blockValidate,
                                 entryOrdinal);
 
-                        const bool matchesPinned =
-                                round->matchesSelection(scenarioName, entryOrdinal);
+                        const bool matchesPinned = round->matchesSelection(
+                                scenarioName, scenarioOrdinal);
                         if (matchesPinned) {
                                 sawPinnedEntry = true;
                         }

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -2431,6 +2431,9 @@ static SnapshotRunResult processFileIterative(const CommandLineOptions &options,
 		SnapshotPlaybackExecutor executor(canvas, options, path, source,
 										sharedResources, round, progress);
 
+		bool executionFailed = false;
+		std::string executionError;
+
 		try {
 			document.render(executor);
 		} catch (Exception &e) {
@@ -2439,20 +2442,18 @@ static SnapshotRunResult processFileIterative(const CommandLineOptions &options,
 			if (e.hasStatement()) {
 				message << " near \"" << e.getStatement() << "\"";
 			}
-			run.fileFailed = true;
-			run.exitCode = 1;
-			run.fileError = message.str();
-			std::cerr << path << ": " << run.fileError << std::endl;
-			return run;
+			executionFailed = true;
+			executionError = message.str();
 		} catch (std::exception &e) {
-			run.fileFailed = true;
-			run.exitCode = 1;
-			run.fileError = e.what();
-			std::cerr << path << ": " << run.fileError << std::endl;
-			return run;
+			executionFailed = true;
+			executionError = e.what();
 		}
 
 		if (!round.hasPinned) {
+			if (executionFailed) {
+				std::cerr << path << ": " << executionError
+				          << " (ignored: no snapshots executed)." << std::endl;
+			}
 			coordinator.completeRound(round);
 			break;
 		}
@@ -2466,48 +2467,58 @@ static SnapshotRunResult processFileIterative(const CommandLineOptions &options,
 		result.blockIndex =
 			(round.invocations.empty() ? 0 : round.invocations[0].blockIndex);
 		result.identifier = buildEntryIdentifier(snapshotBase, round.scenario,
-				result.blockIndex, round.entryOrdinal);
+						result.blockIndex, round.entryOrdinal);
 
-		NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> *raster =
-			canvas.accessRaster();
-		if (!executor.finished()) {
-			result.message = "did not execute all snapshot invocations";
+		if (executionFailed) {
+			result.message = executionError;
 			result.success = false;
+			run.fileFailed = true;
+			run.exitCode = 1;
+			run.fileError = executionError;
 			std::cerr << path << ": scenario " << result.scenarioName
-					  << " did not execute all snapshot invocations."
-					  << std::endl;
-		} else if (raster == 0) {
-			result.message = "rendered image is empty";
-			result.success = false;
-			std::cerr << path << ": scenario " << result.scenarioName
-					  << " produced no raster output." << std::endl;
-		} else if (options.listOnly) {
-			result.rendered = false;
-			result.skipped = true;
-			result.success = true;
+			                  << ": " << result.message << std::endl;
 		} else {
-			result.rendered = true;
-			const SeenScenario *scenarioRecord =
-				progress.findScenarioRecord(round.scenario);
-			const bool multipleEntries =
-				(scenarioRecord != 0 && scenarioRecord->maxOrdinal > 1);
-			SnapshotGolden golden(path, snapshotBase, round.scenario,
-				multipleEntries, round.entryOrdinal, options);
-			if (!round.validate) {
-				if (!golden.writeDraft(*raster, result)) {
-					if (result.message.empty()) {
-						result.message = "failed to write draft";
-					}
-					std::cerr << path << ": scenario "
-							  << result.scenarioName << ": "
-							  << result.message << std::endl;
-				}
-			} else if (!golden.validate(*raster, options.forceUpdate, result)) {
-				if (result.message.empty()) {
-					result.message = "validation failed";
-				}
+			NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> *raster =
+					canvas.accessRaster();
+			if (!executor.finished()) {
+				result.message = "did not execute all snapshot invocations";
+				result.success = false;
 				std::cerr << path << ": scenario " << result.scenarioName
-						  << ": " << result.message << std::endl;
+				                  << " did not execute all snapshot invocations."
+				                  << std::endl;
+			} else if (raster == 0) {
+				result.message = "rendered image is empty";
+				result.success = false;
+				std::cerr << path << ": scenario " << result.scenarioName
+				                  << " produced no raster output." << std::endl;
+			} else if (options.listOnly) {
+				result.rendered = false;
+				result.skipped = true;
+				result.success = true;
+			} else {
+				result.rendered = true;
+				const SeenScenario *scenarioRecord =
+						progress.findScenarioRecord(round.scenario);
+				const bool multipleEntries =
+						(scenarioRecord != 0 && scenarioRecord->maxOrdinal > 1);
+				SnapshotGolden golden(path, snapshotBase, round.scenario,
+						multipleEntries, round.entryOrdinal, options);
+				if (!round.validate) {
+					if (!golden.writeDraft(*raster, result)) {
+						if (result.message.empty()) {
+							result.message = "failed to write draft";
+						}
+						std::cerr << path << ": scenario "
+						                  << result.scenarioName << ": "
+						                  << result.message << std::endl;
+					}
+				} else if (!golden.validate(*raster, options.forceUpdate, result)) {
+					if (result.message.empty()) {
+						result.message = "validation failed";
+					}
+					std::cerr << path << ": scenario " << result.scenarioName
+					                  << ": " << result.message << std::endl;
+				}
 			}
 		}
 

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -26,6 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 
 #include <algorithm>
+#include <atomic>
 #include <cerrno>
 #include <climits>
 #include <codecvt>
@@ -41,6 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <locale>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -2568,6 +2570,33 @@ static SnapshotRunResult processFile(const CommandLineOptions &options,
         return run;
 }
 
+static uint32_t determineThreadCount(const CommandLineOptions &options,
+                                                                        size_t jobCount) {
+        if (jobCount == 0) {
+                return 1;
+        }
+
+        if (options.exitOnFirstFailure) {
+                return 1;
+        }
+
+        uint32_t threads = options.threads;
+        if (threads == 0) {
+                const unsigned int hardware = std::thread::hardware_concurrency();
+                threads = (hardware > 0 ? hardware : 1);
+        }
+
+        if (threads == 0) {
+                threads = 1;
+        }
+
+        if (threads > jobCount) {
+                threads = static_cast<uint32_t>(jobCount);
+        }
+
+        return (threads == 0 ? 1 : threads);
+}
+
 #if !defined(IVG_SNAPSHOT_TESTING)
 
 int main(int argc, char **argv) {
@@ -2576,24 +2605,95 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
-	SnapshotTotals totals;
-	int exitCode = 0;
-	for (size_t i = 0; i < options.ivgPaths.size(); ++i) {
-		const std::string &path = options.ivgPaths[i];
-		SnapshotRunResult run = processFile(options, path);
-		totals.accumulate(run);
-		logFileReport(path, run);
-		if (run.exitCode != 0 || run.fileFailed) {
-			if (exitCode == 0) {
-				exitCode = (run.exitCode != 0 ? run.exitCode : 1);
-			}
-			if (options.exitOnFirstFailure) {
-				break;
-			}
-		}
-	}
-	logTotalsSummary(totals);
-	return exitCode;
+        SnapshotTotals totals;
+        int exitCode = 0;
+        const size_t fileCount = options.ivgPaths.size();
+        const uint32_t threadCount = determineThreadCount(options, fileCount);
+
+        if (threadCount <= 1) {
+                for (size_t i = 0; i < fileCount; ++i) {
+                        const std::string &path = options.ivgPaths[i];
+                        SnapshotRunResult run = processFile(options, path);
+                        totals.accumulate(run);
+                        logFileReport(path, run);
+                        if (run.exitCode != 0 || run.fileFailed) {
+                                if (exitCode == 0) {
+                                        exitCode = (run.exitCode != 0 ? run.exitCode : 1);
+                                }
+                                if (options.exitOnFirstFailure) {
+                                        break;
+                                }
+                        }
+                }
+        } else {
+                std::vector<SnapshotRunResult> runs(fileCount);
+                std::vector<uint8_t> processed(fileCount, 0);
+                std::deque<size_t> pending;
+                for (size_t i = 0; i < fileCount; ++i) {
+                        pending.push_back(i);
+                }
+
+                std::mutex queueMutex;
+                std::atomic<bool> stop(false);
+                std::vector<std::thread> workers;
+                workers.reserve(threadCount);
+
+                for (uint32_t t = 0; t < threadCount; ++t) {
+                        workers.push_back(std::thread([&options, &pending, &queueMutex, &stop,
+                                                                                 &runs, &processed]() {
+                                while (true) {
+                                        if (stop.load()) {
+                                                break;
+                                        }
+
+                                        size_t index = static_cast<size_t>(-1);
+                                        {
+                                                std::lock_guard<std::mutex> lock(queueMutex);
+                                                if (stop.load() || pending.empty()) {
+                                                        break;
+                                                }
+                                                index = pending.front();
+                                                pending.pop_front();
+                                        }
+
+                                        const std::string &path = options.ivgPaths[index];
+                                        SnapshotRunResult run = processFile(options, path);
+                                        runs[index] = run;
+                                        processed[index] = 1;
+
+                                        if (options.exitOnFirstFailure &&
+                                                (run.exitCode != 0 || run.fileFailed)) {
+                                                stop.store(true);
+                                        }
+                                }
+                        }));
+                }
+
+                for (size_t i = 0; i < workers.size(); ++i) {
+                        workers[i].join();
+                }
+
+                for (size_t i = 0; i < fileCount; ++i) {
+                        if (!processed[i]) {
+                                continue;
+                        }
+
+                        const std::string &path = options.ivgPaths[i];
+                        SnapshotRunResult &run = runs[i];
+                        totals.accumulate(run);
+                        logFileReport(path, run);
+                        if (run.exitCode != 0 || run.fileFailed) {
+                                if (exitCode == 0) {
+                                        exitCode = (run.exitCode != 0 ? run.exitCode : 1);
+                                }
+                                if (options.exitOnFirstFailure) {
+                                        break;
+                                }
+                        }
+                }
+        }
+        logTotalsSummary(totals);
+        return exitCode;
 }
 
 #endif // !defined(IVG_SNAPSHOT_TESTING)

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -104,34 +104,11 @@ class CachedDocument {
 	IMPD::String source;
 };
 
-struct SnapshotBlock {
-	bool validate;
-	String scenario;
-	StringVector statements;
-	uint32_t sourceLine;
-};
-
 struct SnapshotInvocation {
-	uint32_t blockIndex;
-	uint32_t sourceLine;
-	uint32_t statementOrdinal;
-	String statements;
-};
-
-struct SnapshotEntry {
-	uint32_t scenarioIndex;
-	uint32_t entryOrdinal;
-	bool validate;
-	String scenarioName;
-	std::vector<SnapshotInvocation> invocations;
-};
-
-struct SnapshotScenario {
-	String name;
-	bool validate;
-	bool explicitScenario;
-	std::vector<uint32_t> entryIndices;
-	std::map<uint32_t, uint32_t> entryLookup;
+        uint32_t blockIndex;
+        uint32_t sourceLine;
+        uint32_t statementOrdinal;
+        String statements;
 };
 struct SnapshotRoundState {
         SnapshotRoundState() { reset(); }
@@ -199,26 +176,38 @@ struct SnapshotRoundState {
         std::vector<SnapshotInvocation> invocations;
 };
 
+struct ScenarioEntryMetadata {
+        ScenarioEntryMetadata() : hasDetails(false), firstSourceLine(0) {}
+
+        bool hasDetails;
+        uint32_t firstSourceLine;
+        std::vector<SnapshotInvocation> invocations;
+};
+
 struct SeenScenario {
-	SeenScenario()
-	        : explicitLabel(false), validate(false), maxOrdinal(0) {}
+        SeenScenario()
+                : explicitLabel(false), validate(false), maxOrdinal(0) {}
 
-	void ensureCapacity(uint32_t ordinal) {
-		if (ordinal == 0) {
-			return;
-		}
+        void ensureCapacity(uint32_t ordinal) {
+                if (ordinal == 0) {
+                        return;
+                }
 
-		if (ordinal > maxOrdinal) {
-			maxOrdinal = ordinal;
-		}
+                if (ordinal > maxOrdinal) {
+                        maxOrdinal = ordinal;
+                }
 
-		if (processed.size() < maxOrdinal) {
-			processed.resize(maxOrdinal, false);
-		}
-	}
+                if (processed.size() < maxOrdinal) {
+                        processed.resize(maxOrdinal, false);
+                }
 
-	bool isProcessed(uint32_t ordinal) const {
-		if (ordinal == 0) {
+                if (entryDetails.size() < maxOrdinal) {
+                        entryDetails.resize(maxOrdinal);
+                }
+        }
+
+        bool isProcessed(uint32_t ordinal) const {
+                if (ordinal == 0) {
 			return true;
 		}
 
@@ -235,14 +224,33 @@ struct SeenScenario {
 			return;
 		}
 
-		processed[ordinal - 1] = true;
-	}
+                processed[ordinal - 1] = true;
+        }
 
-	String name;
-	bool explicitLabel;
-	bool validate;
-	uint32_t maxOrdinal;
-	std::vector<bool> processed;
+        ScenarioEntryMetadata &accessEntryMetadata(uint32_t ordinal) {
+                ensureCapacity(ordinal);
+                if (ordinal == 0) {
+                        throw std::runtime_error("entry ordinal must be >= 1");
+                }
+                return entryDetails[ordinal - 1];
+        }
+
+        const ScenarioEntryMetadata *getEntryMetadata(uint32_t ordinal) const {
+                if (ordinal == 0) {
+                        return 0;
+                }
+                if (ordinal > entryDetails.size()) {
+                        return 0;
+                }
+                return &entryDetails[ordinal - 1];
+        }
+
+        String name;
+        bool explicitLabel;
+        bool validate;
+        uint32_t maxOrdinal;
+        std::vector<bool> processed;
+        std::vector<ScenarioEntryMetadata> entryDetails;
 };
 
 class SnapshotProgress {
@@ -347,6 +355,25 @@ class SnapshotProgress {
                 scenario.markProcessed(entryOrdinal);
         }
 
+        void recordRoundDetails(const SnapshotRoundState &round) {
+                if (!round.hasPinned) {
+                        return;
+                }
+
+                const auto lookupIterator = scenarioLookup.find(round.scenario);
+                if (lookupIterator == scenarioLookup.end()) {
+                        throw std::runtime_error(
+                                "unknown scenario while recording round details");
+                }
+
+                SeenScenario &scenario = seenScenarios[lookupIterator->second];
+                ScenarioEntryMetadata &metadata =
+                        scenario.accessEntryMetadata(round.entryOrdinal);
+                metadata.hasDetails = true;
+                metadata.firstSourceLine = round.firstSourceLine;
+                metadata.invocations = round.invocations;
+        }
+
         const SeenScenario *findScenarioRecord(const String &scenarioName) const {
                 const auto lookupIterator = scenarioLookup.find(scenarioName);
                 if (lookupIterator == scenarioLookup.end()) {
@@ -358,6 +385,10 @@ class SnapshotProgress {
         bool hasUnprocessedEntries() const {
                 Target target;
                 return findNextUnprocessedTarget(target);
+        }
+
+        const std::vector<SeenScenario> &getSeenScenarios() const {
+                return seenScenarios;
         }
 
 private:
@@ -1227,23 +1258,8 @@ static bool writeRasterToPng(
 	const std::string &path,
 	const NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> &raster,
 	std::string &error);
-static SnapshotEntryResult
-renderEntry(const CommandLineOptions &options, const std::string &path,
-		const std::string &snapshotBase, const CachedDocument &document,
-		SharedResources &sharedResources, const SnapshotScenario &scenario,
-		const SnapshotEntry &entry);
-
 class SnapshotGolden {
   public:
-        SnapshotGolden(const std::string &ivgPath, const std::string &snapshotBase,
-                                   const SnapshotScenario &scenario, const SnapshotEntry &entry,
-                                   const CommandLineOptions &options) {
-                initializePaths(ivgPath, snapshotBase,
-                                stringFromIMPD(entry.scenarioName),
-                                scenario.entryIndices.size() > 1, entry.entryOrdinal,
-                                options);
-        }
-
         SnapshotGolden(const std::string &ivgPath, const std::string &snapshotBase,
                                    const String &scenarioName, bool multipleEntries,
                                    uint32_t entryOrdinal,
@@ -1792,284 +1808,6 @@ static bool writeRasterToPng(
 	return false;
 }
 
-class SnapshotPlan {
-  public:
-	explicit SnapshotPlan(const std::string &ivgPath)
-		: baseName(extractBaseName(ivgPath)), nextBlockOrdinal(1),
-		  collectingPlan(false), activeScenarioIndex(0), activeEntryOrdinal(1),
-		  collectionRunCursor(0), collectionRunsBuilt(false),
-		  recordedBlockCursor(0) {}
-
-	uint32_t addBlock(Interpreter &interpreter, const SnapshotBlock &block) {
-		if (block.statements.empty()) {
-			Interpreter::throwBadSyntax(
-				"snapshot meta requires at least one statement block.");
-		}
-
-		uint32_t blockOrdinal = nextBlockOrdinal;
-		if (collectionRunsBuilt) {
-			if (recordedBlockCursor >= recordedBlockOrdinals.size()) {
-				Interpreter::throwBadSyntax(
-					"snapshot replay encountered an unexpected block.");
-			}
-			blockOrdinal = recordedBlockOrdinals[recordedBlockCursor++];
-			return blockOrdinal;
-		}
-
-		recordedBlockOrdinals.push_back(blockOrdinal);
-		const bool hasExplicitScenario = !block.scenario.empty();
-		if (hasExplicitScenario) {
-			const uint32_t scenarioIndex = resolveScenario(
-				interpreter, block.scenario, block.validate, true);
-			SnapshotScenario &scenario = scenarios[scenarioIndex];
-			const uint32_t statementCount =
-				static_cast<uint32_t>(block.statements.size());
-			if (!scenario.entryIndices.empty() &&
-				statementCount != scenario.entryIndices.size()) {
-				Interpreter::throwBadSyntax(
-					"scenario entry count does not match previous blocks.");
-			}
-
-			for (uint32_t i = 0; i < statementCount; ++i) {
-				const uint32_t entryOrdinal = i + 1;
-				SnapshotEntry &entry =
-					ensureEntry(scenarioIndex, scenario, entryOrdinal,
-								block.validate, block.scenario);
-
-				SnapshotInvocation invocation;
-				invocation.blockIndex = blockOrdinal;
-				invocation.sourceLine = block.sourceLine;
-				invocation.statementOrdinal = entryOrdinal;
-				invocation.statements = block.statements[i];
-				entry.invocations.push_back(invocation);
-			}
-		} else {
-			const uint32_t statementCount =
-				static_cast<uint32_t>(block.statements.size());
-			for (uint32_t i = 0; i < statementCount; ++i) {
-				const uint32_t entryOrdinal = 1;
-				const String scenarioName =
-					synthesizeScenarioName(blockOrdinal, statementCount, i + 1);
-				const uint32_t scenarioIndex = resolveScenario(
-					interpreter, scenarioName, block.validate, false);
-				SnapshotScenario &scenario = scenarios[scenarioIndex];
-				SnapshotEntry &entry =
-					ensureEntry(scenarioIndex, scenario, entryOrdinal,
-								block.validate, scenarioName);
-
-				SnapshotInvocation invocation;
-				invocation.blockIndex = blockOrdinal;
-				invocation.sourceLine = block.sourceLine;
-				invocation.statementOrdinal = i + 1;
-				invocation.statements = block.statements[i];
-				entry.invocations.push_back(invocation);
-			}
-		}
-
-		++nextBlockOrdinal;
-		return blockOrdinal;
-	}
-
-	const std::vector<SnapshotScenario> &getScenarios() const {
-		return scenarios;
-	}
-	const std::vector<SnapshotEntry> &getEntries() const { return entries; }
-	const String &getBaseName() const { return baseName; }
-
-	void beginCollection() {
-		collectingPlan = true;
-		activeScenarioIndex = 0;
-		activeEntryOrdinal = 1;
-		collectionRuns.clear();
-		collectionRunCursor = 0;
-		collectionRunsBuilt = false;
-		recordedBlockOrdinals.clear();
-		recordedBlockCursor = 0;
-	}
-
-	void completeCollectionPass() { collectingPlan = false; }
-
-	bool prepareNextCollectionPass() {
-		if (!collectionRunsBuilt) {
-			buildCollectionRuns();
-			collectionRunsBuilt = true;
-			if (collectionRuns.empty()) {
-				return false;
-			}
-			collectionRunCursor = 0;
-			recordedBlockCursor = 0;
-		}
-
-		if (collectionRuns.empty()) {
-			return false;
-		}
-		if (collectionRunCursor + 1 >= collectionRuns.size()) {
-			return false;
-		}
-
-		++collectionRunCursor;
-		const CollectionRun &run = collectionRuns[collectionRunCursor];
-		activeScenarioIndex = run.scenarioIndex;
-		activeEntryOrdinal = run.entryOrdinal;
-		collectingPlan = true;
-		recordedBlockCursor = 0;
-		return true;
-	}
-
-	bool isCollectingPlan() const { return collectingPlan; }
-
-	uint32_t getActiveScenarioIndex() const { return activeScenarioIndex; }
-
-	uint32_t getActiveEntryOrdinal() const { return activeEntryOrdinal; }
-
-	const SnapshotInvocation *lookupInvocation(uint32_t blockOrdinal,
-											   uint32_t scenarioIndex,
-											   uint32_t entryOrdinal) const {
-		if (scenarioIndex >= scenarios.size()) {
-			return 0;
-		}
-
-		const SnapshotScenario &scenario = scenarios[scenarioIndex];
-		if (entryOrdinal == 0 || entryOrdinal > scenario.entryIndices.size()) {
-			return 0;
-		}
-
-		const uint32_t entryIndex = scenario.entryIndices[entryOrdinal - 1];
-		const SnapshotEntry &entry = entries[entryIndex];
-		for (size_t i = 0; i < entry.invocations.size(); ++i) {
-			if (entry.invocations[i].blockIndex == blockOrdinal) {
-				return &entry.invocations[i];
-			}
-		}
-		return 0;
-	}
-
-  private:
-	String extractBaseName(const std::string &path) const {
-		const size_t slash = path.find_last_of("/\\");
-		const size_t baseOffset = (slash == std::string::npos ? 0 : slash + 1);
-		size_t dot = path.find_last_of('.');
-		if (dot == std::string::npos || dot < baseOffset) {
-			dot = path.size();
-		}
-		return String(path.c_str() + baseOffset, path.c_str() + dot);
-	}
-
-	String synthesizeScenarioName(uint32_t blockOrdinal, uint32_t blockCount,
-								  uint32_t entryOrdinal) const {
-		String name = baseName;
-		name += '-';
-		name += Interpreter::toString(static_cast<int32_t>(blockOrdinal));
-		if (blockCount > 1) {
-			name += '-';
-			name += Interpreter::toString(static_cast<int32_t>(entryOrdinal));
-		}
-		return name;
-	}
-
-	uint32_t resolveScenario(Interpreter &interpreter, const String &name,
-							 bool validate, bool explicitScenario) {
-		const std::map<String, uint32_t>::const_iterator it =
-			scenarioLookup.find(name);
-		if (it != scenarioLookup.end()) {
-			SnapshotScenario &existing = scenarios[it->second];
-			if (existing.validate != validate) {
-				Interpreter::throwBadSyntax(
-					"scenario switches between validate yes/no.");
-			}
-			return it->second;
-		}
-
-		SnapshotScenario scenario;
-		scenario.name = name;
-		scenario.validate = validate;
-		scenario.explicitScenario = explicitScenario;
-
-		scenarios.push_back(scenario);
-		const uint32_t index = static_cast<uint32_t>(scenarios.size() - 1);
-		scenarioLookup.insert(std::make_pair(name, index));
-		return index;
-	}
-
-	SnapshotEntry &ensureEntry(uint32_t scenarioIndex,
-							   SnapshotScenario &scenario,
-							   uint32_t entryOrdinal, bool validate,
-							   const String &scenarioName) {
-		const std::map<uint32_t, uint32_t>::const_iterator existing =
-			scenario.entryLookup.find(entryOrdinal);
-		if (existing != scenario.entryLookup.end()) {
-			return entries[existing->second];
-		}
-
-		SnapshotEntry entry;
-		entry.scenarioIndex = scenarioIndex;
-		entry.entryOrdinal = entryOrdinal;
-		entry.validate = validate;
-		entry.scenarioName = scenarioName;
-
-		entries.push_back(entry);
-		const uint32_t entryIndex = static_cast<uint32_t>(entries.size() - 1);
-		scenario.entryLookup.insert(std::make_pair(entryOrdinal, entryIndex));
-
-		size_t insertPosition = scenario.entryIndices.size();
-		for (size_t i = 0; i < scenario.entryIndices.size(); ++i) {
-			const SnapshotEntry &existingEntry =
-				entries[scenario.entryIndices[i]];
-			if (existingEntry.entryOrdinal > entryOrdinal) {
-				insertPosition = i;
-				break;
-			}
-		}
-		scenario.entryIndices.insert(
-			scenario.entryIndices.begin() + insertPosition, entryIndex);
-		return entries.back();
-	}
-
-	String baseName;
-	std::vector<SnapshotEntry> entries;
-	std::vector<SnapshotScenario> scenarios;
-	std::map<String, uint32_t> scenarioLookup;
-	uint32_t nextBlockOrdinal;
-	bool collectingPlan;
-	uint32_t activeScenarioIndex;
-	uint32_t activeEntryOrdinal;
-	std::vector<uint32_t> recordedBlockOrdinals;
-	size_t recordedBlockCursor;
-
-	struct CollectionRun {
-		uint32_t scenarioIndex;
-		uint32_t entryOrdinal;
-	};
-
-	std::vector<CollectionRun> collectionRuns;
-	size_t collectionRunCursor;
-	bool collectionRunsBuilt;
-
-	void buildCollectionRuns() {
-		collectionRuns.clear();
-		for (uint32_t scenarioIndex = 0; scenarioIndex < scenarios.size();
-			 ++scenarioIndex) {
-			const SnapshotScenario &scenario = scenarios[scenarioIndex];
-			if (scenario.entryIndices.empty()) {
-				continue;
-			}
-
-			for (uint32_t entryOrdinal = 1;
-				 entryOrdinal <= scenario.entryIndices.size(); ++entryOrdinal) {
-				CollectionRun run;
-				run.scenarioIndex = scenarioIndex;
-				run.entryOrdinal = entryOrdinal;
-				collectionRuns.push_back(run);
-			}
-		}
-
-		if (!collectionRuns.empty()) {
-			const CollectionRun &first = collectionRuns[0];
-			activeScenarioIndex = first.scenarioIndex;
-			activeEntryOrdinal = first.entryOrdinal;
-		}
-	}
-};
 static bool isWhitespace(Char c) {
 	return (c == ' ' || c == '\t' || c == '\r' || c == '\n');
 }
@@ -2117,155 +1855,8 @@ static StringVector parseSnapshotStatements(Interpreter &interpreter,
 
 static bool readFile(const std::string &path, String &contents);
 
-class SnapshotCollector : public Executor {
-  public:
-	SnapshotCollector(SnapshotPlan &plan, const std::string &sourcePath,
-					  const String &sourceText,
-					  const std::vector<std::string> &includeDirs)
-		: plan(plan), sourcePath(sourcePath), sourceText(sourceText),
-		  includeDirs(includeDirs), scanOffset(0) {}
-
-	bool format(Interpreter &interpreter,
-				const FormatInfo &formatInfo) override {
-		(void)interpreter;
-		(void)formatInfo;
-		return true;
-	}
-
-	bool execute(Interpreter &interpreter, const String &instruction,
-				 const String &arguments) override {
-		(void)interpreter;
-		(void)instruction;
-		(void)arguments;
-		return true;
-	}
-
-	bool progress(Interpreter &interpreter, int maxStatementsLeft) override {
-		(void)interpreter;
-		(void)maxStatementsLeft;
-		return true;
-	}
-
-	bool load(Interpreter &interpreter, const WideString &filename,
-			  String &contents) override {
-		(void)interpreter;
-		const std::string utf8(filename.begin(), filename.end());
-		if (readFile(resolveRelativePath(utf8), contents)) {
-			return true;
-		}
-		for (size_t i = 0; i < includeDirs.size(); ++i) {
-			if (readFile(includeDirs[i] + "/" + utf8, contents)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	void trace(Interpreter &interpreter, const WideString &s) override {
-		(void)interpreter;
-		(void)s;
-	}
-
-	bool meta(Interpreter &interpreter, const String &key,
-			  const String &arguments) override {
-		static const String SNAPSHOT_KEY("snapshot-1");
-		if (key != SNAPSHOT_KEY) {
-			return false;
-		}
-
-		ArgumentsContainer args(
-			ArgumentsContainer::parse(interpreter, StringRange(arguments)));
-
-		SnapshotBlock block;
-		block.validate =
-			parseValidateFlag(interpreter, args.fetchOptional("validate"));
-		const String *scenarioLabel = args.fetchOptional("scenario");
-		if (scenarioLabel != 0) {
-			block.scenario = *scenarioLabel;
-		}
-
-
-		block.statements = parseSnapshotStatements(interpreter, args);
-		block.sourceLine = locateMetaLine();
-
-		args.throwIfAnyUnfetched();
-
-		const uint32_t blockOrdinal = plan.addBlock(interpreter, block);
-
-		executeCollectionInvocation(interpreter, blockOrdinal);
-
-		return true;
-	}
-
-  private:
-	void executeCollectionInvocation(Interpreter &interpreter,
-									 uint32_t blockOrdinal) {
-		if (!plan.isCollectingPlan()) {
-			return;
-		}
-
-		const SnapshotInvocation *invocation =
-			plan.lookupInvocation(blockOrdinal, plan.getActiveScenarioIndex(),
-								  plan.getActiveEntryOrdinal());
-		if (invocation == 0) {
-			return;
-		}
-
-		const StringRange trimmed =
-			trimRange(StringRange(invocation->statements));
-		if (trimmed.b == trimmed.e) {
-			return;
-		}
-
-		interpreter.run(StringRange(invocation->statements));
-	}
-
-	std::string resolveRelativePath(const std::string &requested) const {
-		const size_t slash = sourcePath.find_last_of("/\\");
-		if (slash == std::string::npos) {
-			return requested;
-		}
-		return sourcePath.substr(0, slash + 1) + requested;
-	}
-
-	uint32_t locateMetaLine() {
-		static const String TOKEN("meta snapshot");
-		const size_t position = sourceText.find(TOKEN, scanOffset);
-		if (position == String::npos) {
-			return 0;
-		}
-
-		scanOffset = position + TOKEN.size();
-		uint32_t line = 1;
-		for (size_t i = 0; i < position; ++i) {
-			if (sourceText[i] == '\n') {
-				++line;
-			}
-		}
-		return line;
-	}
-
-	SnapshotPlan &plan;
-	std::string sourcePath;
-	String sourceText;
-	std::vector<std::string> includeDirs;
-	size_t scanOffset;
-};
-
 class SnapshotPlaybackExecutor : public IVG::IVGExecutor {
   public:
-        SnapshotPlaybackExecutor(IVG::Canvas &canvas,
-                                                         const SnapshotScenario &scenario,
-                                                         const SnapshotEntry &entry,
-                                                         const CommandLineOptions &options,
-                                                         const std::string &sourcePath,
-                                                         SharedResources &sharedResources)
-                : SnapshotPlaybackExecutor(canvas, options, sourcePath,
-                                sharedResources) {
-                legacyScenario = &scenario;
-                legacyEntry = &entry;
-        }
-
         SnapshotPlaybackExecutor(IVG::Canvas &canvas,
                                                          const CommandLineOptions &options,
                                                          const std::string &sourcePath,
@@ -2361,21 +1952,17 @@ class SnapshotPlaybackExecutor : public IVG::IVGExecutor {
                         return false;
                 }
 
+                if (round == 0 || progress == 0) {
+                        Interpreter::throwBadSyntax(
+                                "snapshot playback executor missing round context.");
+                }
+
                 ArgumentsContainer args(
                         ArgumentsContainer::parse(interpreter, StringRange(arguments)));
-                if (isRoundMode()) {
-                        return handleRoundMeta(interpreter, args);
-                }
-
-                return handleLegacyMeta(interpreter, args);
+                return handleRoundMeta(interpreter, args);
         }
 
-        bool finished() const {
-                if (legacyEntry == 0) {
-                        return true;
-                }
-                return (invocationCursor == legacyEntry->invocations.size());
-        }
+        bool finished() const { return true; }
 
   private:
         SnapshotPlaybackExecutor(IVG::Canvas &canvas,
@@ -2385,90 +1972,8 @@ class SnapshotPlaybackExecutor : public IVG::IVGExecutor {
                 : IVG::IVGExecutor(canvas), includeDirs(options.includeDirs),
                   fontDirs(options.fontDirs), imageDirs(options.imageDirs),
                   sourcePath(sourcePath), verbose(options.verbose),
-                  sharedResources(sharedResources), legacyScenario(0), legacyEntry(0),
-                  round(0), progress(0), sourceText(), nextBlockOrdinal(0),
-                  invocationCursor(0), scanOffset(0) {}
-
-        bool isRoundMode() const { return (round != 0 && progress != 0); }
-
-        bool handleLegacyMeta(Interpreter &interpreter, ArgumentsContainer &args) {
-                if (legacyScenario == 0 || legacyEntry == 0) {
-                        Interpreter::throwBadSyntax(
-                                "snapshot playback executor missing legacy plan context.");
-                }
-
-                const String *validateFlag = args.fetchOptional("validate");
-                const bool blockValidate =
-                        parseValidateFlag(interpreter, validateFlag);
-                const String *scenarioLabel = args.fetchOptional("scenario");
-                const bool hasLabel = (scenarioLabel != 0);
-
-                const uint32_t blockOrdinal = ++nextBlockOrdinal;
-
-                const SnapshotInvocation *invocation = 0;
-                if (invocationCursor < legacyEntry->invocations.size()) {
-                        const SnapshotInvocation &candidate =
-                                legacyEntry->invocations[invocationCursor];
-                        if (candidate.blockIndex == blockOrdinal) {
-                                invocation = &candidate;
-                                ++invocationCursor;
-                        }
-                }
-
-                const bool blockTargetsScenario =
-                        (legacyScenario->explicitScenario
-                                 ? (hasLabel && *scenarioLabel == legacyScenario->name)
-                                 : (!hasLabel && invocation != 0));
-
-                if (!blockTargetsScenario) {
-                        args.throwIfAnyUnfetched();
-                        if (invocation != 0) {
-                                Interpreter::throwBadSyntax(
-                                        "unexpected snapshot invocation for scenario.");
-                        }
-                        return true;
-                }
-
-                if (invocation == 0) {
-                        Interpreter::throwBadSyntax(
-                                "missing snapshot invocation for scenario block.");
-                }
-
-                if (blockValidate != legacyEntry->validate) {
-                        Interpreter::throwBadSyntax(
-                                "snapshot validate flag changed between collection and playback.");
-                }
-
-                StringVector statements = parseSnapshotStatements(interpreter, args);
-                if (invocation->statementOrdinal == 0 ||
-                        invocation->statementOrdinal > statements.size()) {
-                        Interpreter::throwBadSyntax(
-                                "snapshot statement ordinal exceeds available entries.");
-                }
-
-                const String &statementBody =
-                        statements[invocation->statementOrdinal - 1];
-                if (statementBody != invocation->statements) {
-                        Interpreter::throwBadSyntax(
-                                "snapshot statements changed between collection and playback.");
-                }
-
-                args.throwIfAnyUnfetched();
-
-                if (verbose) {
-                        std::cout << sourcePath << ": scenario "
-                                          << legacyEntry->scenarioName << " entry "
-                                          << legacyEntry->entryOrdinal << " block "
-                                          << invocation->blockIndex << " (statement "
-                                          << invocation->statementOrdinal << ")"
-                                          << std::endl;
-                }
-
-                IVG::Context invocationContext(currentContext->accessCanvas(),
-                                                                           *currentContext);
-                runInNewContext(interpreter, invocationContext, statementBody);
-                return true;
-        }
+                  sharedResources(sharedResources), round(0), progress(0), sourceText(),
+                  scanOffset(0) {}
 
         bool handleRoundMeta(Interpreter &interpreter, ArgumentsContainer &args) {
                 const String *validateFlag = args.fetchOptional("validate");
@@ -2604,13 +2109,9 @@ class SnapshotPlaybackExecutor : public IVG::IVGExecutor {
         std::string sourcePath;
         bool verbose;
         SharedResources &sharedResources;
-        const SnapshotScenario *legacyScenario;
-        const SnapshotEntry *legacyEntry;
         SnapshotRoundState *round;
         SnapshotProgress *progress;
         String sourceText;
-        uint32_t nextBlockOrdinal;
-        size_t invocationCursor;
         size_t scanOffset;
 
 	bool loadExternalFont(const WideString &fontName, IVG::Font &font) {
@@ -2820,548 +2321,55 @@ static bool parseCommandLine(int argc, char **argv,
 }
 
 static bool readFile(const std::string &path, String &contents) {
-	std::ifstream stream(path.c_str(), std::ios::binary);
-	if (!stream.good()) {
-		return false;
-	}
-	std::string buffer((std::istreambuf_iterator<char>(stream)),
-					   std::istreambuf_iterator<char>());
-	contents.assign(buffer.begin(), buffer.end());
-	return true;
+        std::ifstream stream(path.c_str(), std::ios::binary);
+        if (!stream.good()) {
+                return false;
+        }
+        std::string buffer((std::istreambuf_iterator<char>(stream)),
+                                           std::istreambuf_iterator<char>());
+        contents.assign(buffer.begin(), buffer.end());
+        return true;
 }
 
-static void printPlan(const std::string &path, const SnapshotPlan &plan) {
-	std::cout << path << std::endl;
-	const std::vector<SnapshotScenario> &scenarios = plan.getScenarios();
-	const std::vector<SnapshotEntry> &entries = plan.getEntries();
+static void printScenarioListing(const std::string &path,
+                                                            const SnapshotProgress &progress) {
+        std::cout << path << std::endl;
+        const std::vector<SeenScenario> &scenarios = progress.getSeenScenarios();
+        for (size_t i = 0; i < scenarios.size(); ++i) {
+                const SeenScenario &scenario = scenarios[i];
+                std::cout << "  Scenario " << stringFromIMPD(scenario.name)
+                                  << " (validate: " << (scenario.validate ? "yes" : "no")
+                                  << ")" << std::endl;
+                for (uint32_t ordinal = 1; ordinal <= scenario.maxOrdinal; ++ordinal) {
+                        if (!scenario.isProcessed(ordinal)) {
+                                continue;
+                        }
 
-	for (size_t i = 0; i < scenarios.size(); ++i) {
-		const SnapshotScenario &scenario = scenarios[i];
-		std::cout << "	Scenario " << scenario.name
-				  << " (validate: " << (scenario.validate ? "yes" : "no") << ")"
-				  << std::endl;
-		for (size_t j = 0; j < scenario.entryIndices.size(); ++j) {
-			const SnapshotEntry &entry = entries[scenario.entryIndices[j]];
-			std::cout << "		Entry " << entry.entryOrdinal << std::endl;
-			for (size_t k = 0; k < entry.invocations.size(); ++k) {
-				const SnapshotInvocation &invocation = entry.invocations[k];
-				std::cout << "			Block " << invocation.blockIndex
-						  << " (statement " << invocation.statementOrdinal
-						  << "), line " << invocation.sourceLine << std::endl;
+                        std::cout << "          Entry " << ordinal << std::endl;
+                        const ScenarioEntryMetadata *metadata =
+                                scenario.getEntryMetadata(ordinal);
+                        if (metadata == 0) {
+                                continue;
+                        }
 
-				std::istringstream snippet(invocation.statements);
-				std::string line;
-				while (std::getline(snippet, line)) {
-					std::cout << "				" << line << std::endl;
-				}
-			}
-		}
-	}
-}
-struct SnapshotJob {
-	SnapshotJob()
-		: options(0), ivgPath(0), snapshotBase(0), document(0), sharedResources(0),
-		  scenario(0), entry(0), planOrdinal(0), sentinel(false) {}
+                        for (size_t k = 0; k < metadata->invocations.size(); ++k) {
+                                const SnapshotInvocation &invocation =
+                                        metadata->invocations[k];
+                                std::cout << "                  Block " << invocation.blockIndex
+                                                  << " (statement " << invocation.statementOrdinal
+                                                  << "), line " << invocation.sourceLine
+                                                  << std::endl;
 
-	const CommandLineOptions *options;
-	const std::string *ivgPath;
-	const std::string *snapshotBase;
-	const CachedDocument *document;
-	SharedResources *sharedResources;
-	const SnapshotScenario *scenario;
-	const SnapshotEntry *entry;
-	uint32_t planOrdinal;
-	bool sentinel;
-};
-
-class SnapshotScheduler {
-  public:
-	SnapshotScheduler(uint32_t threadCount, bool exitOnFirstFailure)
-		: threadCount(threadCount == 0 ? 1 : threadCount),
-		  exitOnFirstFailure(exitOnFirstFailure), started(false),
-		  finalizing(false), stopScheduling(false), activeWorkers(0) {}
-
-	~SnapshotScheduler() { finalize(); }
-
-	void start() {
-		if (started) {
-			return;
-		}
-
-		workers.reserve(threadCount);
-		threads.reserve(threadCount);
-		for (uint32_t i = 0; i < threadCount; ++i) {
-			workers.push_back(std::unique_ptr<Worker>(new Worker(*this)));
-			threads.push_back(std::unique_ptr<NuXThreads::Thread>(
-				new NuXThreads::Thread(*workers.back())));
-			threads.back()->start();
-		}
-		started = true;
-	}
-
-	bool enqueue(const SnapshotJob &job) {
-		NuXThreads::MutexLock lock(mutex);
-		if (!started || finalizing || (exitOnFirstFailure && stopScheduling)) {
-			return false;
-		}
-
-		pendingJobs.push_back(job);
-		jobAvailable.signal();
-		return true;
-	}
-
-	bool fetchResult(SnapshotEntryResult &out, bool wait) {
-		while (true) {
-			{
-				NuXThreads::MutexLock lock(mutex);
-				if (!completedResults.empty()) {
-					out = completedResults.front();
-					completedResults.pop_front();
-					return true;
-				}
-				if (!wait) {
-					return false;
-				}
-				if (finalizing && pendingJobs.empty() && activeWorkers == 0) {
-					return false;
-				}
-			}
-			resultAvailable.wait();
-		}
-	}
-
-	void finalize() {
-		if (!started) {
-			return;
-		}
-
-		uint32_t sentinelCount = 0;
-		{
-			NuXThreads::MutexLock lock(mutex);
-			if (!finalizing) {
-				finalizing = true;
-				stopScheduling = true;
-				sentinelCount = threadCount;
-				for (uint32_t i = 0; i < sentinelCount; ++i) {
-					SnapshotJob sentinelJob;
-					sentinelJob.sentinel = true;
-					pendingJobs.push_back(sentinelJob);
-				}
-			}
-		}
-
-		for (uint32_t i = 0; i < sentinelCount; ++i) {
-			jobAvailable.signal();
-		}
-
-		for (size_t i = 0; i < threads.size(); ++i) {
-			jobAvailable.signal();
-			threads[i]->join();
-		}
-		workers.clear();
-		threads.clear();
-		started = false;
-	}
-
-	bool shouldStopScheduling() {
-		NuXThreads::MutexLock lock(mutex);
-		return stopScheduling;
-	}
-
-  private:
-	class Worker : public NuXThreads::Runnable {
-	  public:
-		explicit Worker(SnapshotScheduler &scheduler) : scheduler(scheduler) {}
-
-		void run() override { scheduler.workerLoop(); }
-
-	  private:
-		SnapshotScheduler &scheduler;
-	};
-
-	void workerLoop() {
-		while (true) {
-			SnapshotJob job;
-			if (!takeJob(job)) {
-				return;
-			}
-			if (job.sentinel) {
-				completeSentinel();
-				return;
-			}
-
-			SnapshotEntryResult result = renderEntry(
-				*job.options, *job.ivgPath, *job.snapshotBase, *job.document,
-				*job.sharedResources, *job.scenario, *job.entry);
-			result.planOrdinal = job.planOrdinal;
-			submitResult(result);
-		}
-	}
-
-	bool takeJob(SnapshotJob &job) {
-		while (true) {
-			{
-				NuXThreads::MutexLock lock(mutex);
-				if (!pendingJobs.empty()) {
-					job = pendingJobs.front();
-					pendingJobs.pop_front();
-					++activeWorkers;
-					return true;
-				}
-				if (finalizing) {
-					return false;
-				}
-			}
-			jobAvailable.wait();
-		}
-	}
-
-	void submitResult(SnapshotEntryResult &result) {
-		const bool success = result.success;
-		{
-			NuXThreads::MutexLock lock(mutex);
-			completedResults.push_back(result);
-			if (!success && exitOnFirstFailure) {
-				stopScheduling = true;
-			}
-			if (activeWorkers > 0) {
-				--activeWorkers;
-			}
-		}
-		resultAvailable.signal();
-	}
-
-	void completeSentinel() {
-		{
-			NuXThreads::MutexLock lock(mutex);
-			if (activeWorkers > 0) {
-				--activeWorkers;
-			}
-		}
-		resultAvailable.signal();
-		jobAvailable.signal();
-	}
-
-	uint32_t threadCount;
-	bool exitOnFirstFailure;
-	bool started;
-	bool finalizing;
-	bool stopScheduling;
-	NuXThreads::Mutex mutex;
-	NuXThreads::Event jobAvailable;
-	NuXThreads::Event resultAvailable;
-	std::deque<SnapshotJob> pendingJobs;
-	std::deque<SnapshotEntryResult> completedResults;
-	std::vector<std::unique_ptr<Worker>> workers;
-	std::vector<std::unique_ptr<NuXThreads::Thread>> threads;
-	uint32_t activeWorkers;
-};
-static SnapshotEntryResult
-renderEntry(const CommandLineOptions &options, const std::string &path,
-			const std::string &snapshotBase, const CachedDocument &document,
-			SharedResources &sharedResources, const SnapshotScenario &scenario,
-			const SnapshotEntry &entry) {
-	SnapshotEntryResult result;
-	result.ivgPath = path;
-	result.scenarioName = stringFromIMPD(entry.scenarioName);
-	result.entryOrdinal = entry.entryOrdinal;
-	result.validate = entry.validate;
-        result.blockIndex =
-                (entry.invocations.empty() ? 0 : entry.invocations[0].blockIndex);
-        result.identifier = buildEntryIdentifier(snapshotBase, entry.scenarioName,
-                        result.blockIndex, entry.entryOrdinal);
-
-	IVG::SelfContainedARGB32Canvas canvas;
-	SnapshotPlaybackExecutor executor(canvas, scenario, entry, options, path,
-									  sharedResources);
-	try {
-		document.render(executor);
-		result.rendered = true;
-	} catch (Exception &e) {
-		std::ostringstream message;
-		message << e.getError();
-		if (e.hasStatement()) {
-			message << " near \"" << e.getStatement() << "\"";
-		}
-		result.message = message.str();
-		std::cerr << path << ": scenario " << result.scenarioName << ": "
-				  << result.message << std::endl;
-		return result;
-	} catch (std::exception &e) {
-		result.message = e.what();
-		std::cerr << path << ": scenario " << result.scenarioName << ": "
-				  << result.message << std::endl;
-		return result;
-	}
-
-	if (!executor.finished()) {
-		result.message = "did not execute all snapshot invocations";
-		std::cerr << path << ": scenario " << result.scenarioName
-				  << " did not execute all snapshot invocations." << std::endl;
-		return result;
-	}
-
-	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> *raster =
-		canvas.accessRaster();
-	if (raster == 0) {
-		result.message = "rendered image is empty";
-		std::cerr << path << ": scenario " << result.scenarioName
-				  << " produced no raster output." << std::endl;
-		return result;
-	}
-
-		SnapshotGolden golden(path, snapshotBase, scenario, entry, options);
-	if (!entry.validate) {
-		if (!golden.writeDraft(*raster, result)) {
-			if (result.message.empty()) {
-				result.message = "failed to write draft";
-			}
-			std::cerr << path << ": scenario " << result.scenarioName << ": "
-					  << result.message << std::endl;
-		}
-		return result;
-	}
-
-	if (!golden.validate(*raster, options.forceUpdate, result)) {
-		if (result.message.empty()) {
-			result.message = "validation failed";
-		}
-		std::cerr << path << ": scenario " << result.scenarioName << ": "
-				  << result.message << std::endl;
-		return result;
-	}
-
-	return result;
-}
-
-static void flushSchedulerResults(SnapshotScheduler &scheduler, bool wait,
-								  std::vector<SnapshotEntryResult> &ordered,
-								  std::vector<bool> &ready,
-								  size_t &nextLogIndex,
-								  SnapshotRunResult &run) {
-	SnapshotEntryResult fetched;
-	bool waitFlag = wait;
-	while (scheduler.fetchResult(fetched, waitFlag)) {
-		waitFlag = false;
-		const uint32_t ordinal = fetched.planOrdinal;
-		if (ordinal >= ordered.size()) {
-			continue;
-		}
-
-		ordered[ordinal] = fetched;
-		ready[ordinal] = true;
-
-		while (nextLogIndex < ordered.size() && ready[nextLogIndex]) {
-			SnapshotEntryResult &recorded = ordered[nextLogIndex];
-			run.entries.push_back(recorded);
-			++run.totalEntries;
-			if (recorded.validate) {
-				++run.validatedEntries;
-			} else {
-				++run.draftEntries;
-			}
-			if (recorded.updated) {
-				++run.updatedEntries;
-			}
-			if (!recorded.success) {
-				++run.failedEntries;
-				if (recorded.diffed) {
-					++run.diffFailures;
-				}
-			}
-			++nextLogIndex;
-		}
-	}
-}
-static SnapshotRunResult renderPlan(const CommandLineOptions &options,
-                                                                        const std::string &path,
-                                                                        const CachedDocument &document,
-                                                                        const SnapshotPlan &plan) {
-        SnapshotRunResult run;
-        const std::vector<SnapshotScenario> &scenarios = plan.getScenarios();
-        const std::vector<SnapshotEntry> &entries = plan.getEntries();
-        const std::string snapshotBase = buildSnapshotSourceTag(path, options.rootDir);
-	SharedResources sharedResources;
-
-	uint32_t threadCount = options.threads;
-	if (threadCount == 0) {
-		const unsigned int hardware = std::thread::hardware_concurrency();
-		threadCount = (hardware > 0 ? hardware : 1);
-	}
-
-	const size_t totalJobs = entries.size();
-	if (totalJobs > 0 && threadCount > totalJobs) {
-		threadCount = static_cast<uint32_t>(totalJobs);
-	}
-
-	SnapshotScheduler scheduler(threadCount, options.exitOnFirstFailure);
-	scheduler.start();
-
-	std::vector<SnapshotEntryResult> ordered;
-	std::vector<bool> ready;
-	size_t nextLogIndex = 0;
-	bool schedulingStopped = false;
-
-	for (size_t i = 0; i < scenarios.size() && !schedulingStopped; ++i) {
-		const SnapshotScenario &scenario = scenarios[i];
-		if (options.verbose) {
-			std::cout << path << ": scenario " << scenario.name
-					  << " (validate: " << (scenario.validate ? "yes" : "no")
-					  << ")" << std::endl;
-		}
-
-		for (size_t j = 0; j < scenario.entryIndices.size(); ++j) {
-			if (options.exitOnFirstFailure &&
-				scheduler.shouldStopScheduling()) {
-				schedulingStopped = true;
-				break;
-			}
-
-			const SnapshotEntry &entry = entries[scenario.entryIndices[j]];
-			if (options.verbose) {
-				std::cout << path << ":	  entry " << entry.entryOrdinal
-						  << " name:" << entry.scenarioName
-						  << " (validate: " << (entry.validate ? "yes" : "no")
-						  << ")" << std::endl;
-			}
-
-			SnapshotJob job;
-			job.options = &options;
-			job.ivgPath = &path;
-			job.snapshotBase = &snapshotBase;
-			job.document = &document;
-			job.sharedResources = &sharedResources;
-			job.scenario = &scenario;
-			job.entry = &entry;
-			job.planOrdinal = static_cast<uint32_t>(ordered.size());
-
-			if (!scheduler.enqueue(job)) {
-				schedulingStopped = true;
-				break;
-			}
-
-			ordered.push_back(SnapshotEntryResult());
-			ready.push_back(false);
-			flushSchedulerResults(scheduler, false, ordered, ready,
-								  nextLogIndex, run);
-		}
-
-		flushSchedulerResults(scheduler, false, ordered, ready, nextLogIndex,
-							  run);
-	}
-
-	flushSchedulerResults(scheduler, false, ordered, ready, nextLogIndex, run);
-	while (nextLogIndex < ordered.size()) {
-		flushSchedulerResults(scheduler, true, ordered, ready, nextLogIndex,
-							  run);
-	}
-
-	scheduler.finalize();
-	flushSchedulerResults(scheduler, true, ordered, ready, nextLogIndex, run);
-
-	if (run.failedEntries > 0) {
-		run.exitCode = 1;
-	}
-	return run;
-}
-static SnapshotRunResult processFileLegacy(const CommandLineOptions &options,
-                                                                         const std::string &path) {
-	SnapshotRunResult run;
-	CachedDocument document;
-	if (!document.loadFromFile(path)) {
-		run.fileFailed = true;
-		run.exitCode = 1;
-		run.fileError = "failed to read IVG file";
-		std::cerr << "failed to read IVG file: " << path << std::endl;
-		return run;
-	}
-
-	SnapshotPlan plan(path);
-	const String &source = document.getSource();
-
-	plan.beginCollection();
-	while (true) {
-		SnapshotCollector collector(plan, path, source, options.includeDirs);
-		STLMapVariables variables;
-		FormatInfo formatInfo;
-		Interpreter interpreter(collector, variables, formatInfo);
-
-		try {
-			interpreter.run(StringRange(source));
-		} catch (Exception &e) {
-			std::ostringstream message;
-			message << e.getError();
-			if (e.hasStatement()) {
-				message << " near \"" << e.getStatement() << "\"";
-			}
-			run.fileFailed = true;
-			run.exitCode = 1;
-			run.fileError = message.str();
-			std::cerr << path << ": " << run.fileError << std::endl;
-			return run;
-		} catch (std::exception &e) {
-			run.fileFailed = true;
-			run.exitCode = 1;
-			run.fileError = e.what();
-			std::cerr << path << ": " << run.fileError << std::endl;
-			return run;
-		}
-
-		plan.completeCollectionPass();
-		if (!plan.prepareNextCollectionPass()) {
-			break;
-		}
-	}
-
-	if (options.listOnly || options.verbose) {
-		printPlan(path, plan);
-	}
-
-	if (options.listOnly) {
-		const std::vector<SnapshotEntry> &entries = plan.getEntries();
-		for (size_t i = 0; i < entries.size(); ++i) {
-			++run.totalEntries;
-			if (entries[i].validate) {
-				++run.validatedEntries;
-			} else {
-				++run.draftEntries;
-			}
-		}
-		run.exitCode = 0;
-		return run;
-	}
-
-	if (options.verbose) {
-		std::cout << path << ": include dirs:";
-		if (options.includeDirs.empty()) {
-			std::cout << " (none)";
-		} else {
-			for (size_t i = 0; i < options.includeDirs.size(); ++i) {
-				std::cout << ' ' << options.includeDirs[i];
-			}
-		}
-		std::cout << std::endl;
-		std::cout << path << ": font dirs:";
-		if (options.fontDirs.empty()) {
-			std::cout << " (none)";
-		} else {
-			for (size_t i = 0; i < options.fontDirs.size(); ++i) {
-				std::cout << ' ' << options.fontDirs[i];
-			}
-		}
-		std::cout << std::endl;
-		std::cout << path << ": image dirs:";
-		if (options.imageDirs.empty()) {
-			std::cout << " (none)";
-		} else {
-			for (size_t i = 0; i < options.imageDirs.size(); ++i) {
-				std::cout << ' ' << options.imageDirs[i];
-			}
-		}
-		std::cout << std::endl;
-	}
-
-	return renderPlan(options, path, document, plan);
+                                std::istringstream snippet(
+                                        stringFromIMPD(invocation.statements));
+                                std::string line;
+                                while (std::getline(snippet, line)) {
+                                        std::cout << "                          " << line
+                                                          << std::endl;
+                                }
+                        }
+                }
+        }
 }
 
 static SnapshotRunResult processFileIterative(const CommandLineOptions &options,
@@ -3520,22 +2528,24 @@ static SnapshotRunResult processFileIterative(const CommandLineOptions &options,
 		}
 		++run.totalEntries;
 
-		run.entries.push_back(result);
+                run.entries.push_back(result);
 
-		coordinator.completeRound(round);
-		if (!stopAfterFailure && !coordinator.needsAnotherRound(round)) {
-			break;
-		}
-	}
+                progress.recordRoundDetails(round);
+                coordinator.completeRound(round);
+                if (!stopAfterFailure && !coordinator.needsAnotherRound(round)) {
+                        break;
+                }
+        }
 
-	return run;
+        if (options.listOnly || options.verbose) {
+                printScenarioListing(path, progress);
+        }
+
+        return run;
 }
 
 static SnapshotRunResult processFile(const CommandLineOptions &options,
                                                                          const std::string &path) {
-        if (options.listOnly) {
-                return processFileLegacy(options, path);
-        }
         SnapshotRunResult run = processFileIterative(options, path);
         if (run.exitCode == 0 && run.failedEntries > 0) {
                 run.exitCode = 1;

--- a/tools/IVGSnapshot/tests/ListOnlySample.ivg
+++ b/tools/IVGSnapshot/tests/ListOnlySample.ivg
@@ -1,3 +1,4 @@
-format snapshot uses:[snapshot-1]
-meta snapshot scenario:smurf list:[ [ set fill red ] [ set stroke blue ] ]
-meta snapshot [ set dash 4 ]
+format ivg-3 uses:snapshot-1
+bounds 0,0,16,16
+meta snapshot scenario:smurf list:[ [ fill red ] [ pen blue width:2 ] ]
+meta snapshot [ pen red dash:4 width:2 ]

--- a/tools/IVGSnapshot/tests/ListOnlySample.txt
+++ b/tools/IVGSnapshot/tests/ListOnlySample.txt
@@ -1,16 +1,27 @@
 tools/IVGSnapshot/tests/ListOnlySample.ivg
-	Scenario smurf (validate: yes)
-		Entry 1
-			Block 1 (statement 1), line 2
-				[ set fill red ]
-		Entry 2
-			Block 1 (statement 2), line 2
-				[ set stroke blue ]
-	Scenario ListOnlySample-2 (validate: yes)
-		Entry 1
-			Block 2 (statement 1), line 3
-				[ set dash 4 ]
+  Scenario smurf (validate: yes)
+          Entry 1
+                  Block 1 (statement 1), line 3
+                          [ fill red ]
+          Entry 2
+                  Block 1 (statement 2), line 3
+                          [ pen blue width:2 ]
+  Scenario implicit-2 (validate: yes)
+          Entry 1
+                  Block 2 (statement 1), line 4
+                          [ pen red dash:4 width:2 ]
 # tools/IVGSnapshot/tests/ListOnlySample.ivg
+
+Scenario: smurf
+	Entry 1 (block 1) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListOnlySample#smurf#1#1
+
+	Entry 2 (block 1) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListOnlySample#smurf#1#2
+
+Scenario: implicit-2
+	Entry 1 (block 2) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListOnlySample#implicit-2#2#1
 
 Summary
   Snapshots       : 3 total (3 validated)

--- a/tools/IVGSnapshot/tests/ListScenarioVariants.ivg
+++ b/tools/IVGSnapshot/tests/ListScenarioVariants.ivg
@@ -1,8 +1,9 @@
-format snapshot uses:[snapshot-1]
-meta snapshot scenario:alpha list:[ [ set fill red ] [ set stroke blue ] ]
-meta snapshot scenario:alpha list:[ [ set highlight gold ] [ set outline green ] ]
-meta snapshot validate:no [ set dash 4 ]
-meta snapshot list:[ [ set implicit-one ] [ set implicit-two ] ]
-meta snapshot [ set implicit-three ]
-meta snapshot scenario:beta validate:no [ set shadow black ]
-meta snapshot scenario:beta validate:no [ set shadow gray ]
+format ivg-3 uses:snapshot-1
+bounds 0,0,20,20
+meta snapshot scenario:alpha list:[ [ fill red ] [ pen blue width:2 ] ]
+meta snapshot scenario:alpha list:[ [ fill #ffd700 ] [ pen green width:3 ] ]
+meta snapshot validate:no [ pen black dash:4 width:2 ]
+meta snapshot list:[ [ fill #112233 ] [ fill #445566 ] ]
+meta snapshot [ fill #778899 ]
+meta snapshot scenario:beta validate:no [ fill black ]
+meta snapshot scenario:beta validate:no [ fill gray ]

--- a/tools/IVGSnapshot/tests/ListScenarioVariants.txt
+++ b/tools/IVGSnapshot/tests/ListScenarioVariants.txt
@@ -1,47 +1,78 @@
 tools/IVGSnapshot/tests/ListScenarioVariants.ivg
-	Scenario alpha (validate: yes)
-		Entry 1
-			Block 1 (statement 1), line 2
-				[ set fill red ]
-			Block 2 (statement 1), line 3
-				[ set highlight gold ]
-		Entry 2
-			Block 1 (statement 2), line 2
-				[ set stroke blue ]
-			Block 2 (statement 2), line 3
-				[ set outline green ]
-	Scenario ListScenarioVariants-3 (validate: no)
-		Entry 1
-			Block 3 (statement 1), line 4
-				[ set dash 4 ]
-	Scenario ListScenarioVariants-4-1 (validate: yes)
-		Entry 1
-			Block 4 (statement 1), line 5
-				[ set implicit-one ]
-	Scenario ListScenarioVariants-4-2 (validate: yes)
-		Entry 1
-			Block 4 (statement 2), line 5
-				[ set implicit-two ]
-	Scenario ListScenarioVariants-5 (validate: yes)
-		Entry 1
-			Block 5 (statement 1), line 6
-				[ set implicit-three ]
-	Scenario beta (validate: no)
-		Entry 1
-			Block 6 (statement 1), line 7
-				[ set shadow black ]
-			Block 7 (statement 1), line 8
-				[ set shadow gray ]
+  Scenario alpha (validate: yes)
+          Entry 1
+                  Block 1 (statement 1), line 3
+                          [ fill red ]
+                  Block 2 (statement 1), line 4
+                          [ fill #ffd700 ]
+          Entry 2
+                  Block 1 (statement 2), line 3
+                          [ pen blue width:2 ]
+                  Block 2 (statement 2), line 4
+                          [ pen green width:3 ]
+  Scenario implicit-3 (validate: no)
+          Entry 1
+                  Block 3 (statement 1), line 5
+                          [ pen black dash:4 width:2 ]
+  Scenario implicit-4-1 (validate: yes)
+          Entry 1
+                  Block 4 (statement 1), line 6
+                          [ fill #112233 ]
+  Scenario implicit-4-2 (validate: yes)
+          Entry 1
+          Entry 2
+                  Block 4 (statement 2), line 6
+                          [ fill #445566 ]
+  Scenario implicit-5 (validate: yes)
+          Entry 1
+                  Block 5 (statement 1), line 7
+                          [ fill #778899 ]
+  Scenario beta (validate: no)
+          Entry 1
+                  Block 6 (statement 1), line 8
+                          [ fill black ]
+                  Block 7 (statement 1), line 9
+                          [ fill gray ]
 # tools/IVGSnapshot/tests/ListScenarioVariants.ivg
 
+Scenario: alpha
+	Entry 1 (block 1) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#alpha#1#1
+
+	Entry 2 (block 1) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#alpha#1#2
+
+Scenario: implicit-3
+	Entry 1 (block 3) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#implicit-3#3#1
+
+Scenario: implicit-4-1
+	Entry 1 (block 4) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#implicit-4-1#4#1
+
+Scenario: implicit-4-2
+	Entry 1 (block 0) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#implicit-4-2#0#1
+
+	Entry 2 (block 4) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#implicit-4-2#4#2
+
+Scenario: implicit-5
+	Entry 1 (block 5) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#implicit-5#5#1
+
+Scenario: beta
+	Entry 1 (block 6) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#beta#6#1
+
 Summary
-  Snapshots       : 7 total (5 validated)
+  Snapshots       : 8 total (6 validated)
   Updated         : 0
   Failed          : 0 (diff failures: 0)
 
 # Overall Summary
 
   Processed files : 1 (0 failed)
-  Snapshots       : 7 total (5 validated)
+  Snapshots       : 8 total (6 validated)
   Updated         : 0
   Failed          : 0 (diff failures: 0)

--- a/tools/IVGSnapshot/tests/ListScenarioVariants.txt
+++ b/tools/IVGSnapshot/tests/ListScenarioVariants.txt
@@ -20,7 +20,6 @@ tools/IVGSnapshot/tests/ListScenarioVariants.ivg
                           [ fill #112233 ]
   Scenario implicit-4-2 (validate: yes)
           Entry 1
-          Entry 2
                   Block 4 (statement 2), line 6
                           [ fill #445566 ]
   Scenario implicit-5 (validate: yes)
@@ -51,11 +50,8 @@ Scenario: implicit-4-1
 	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#implicit-4-1#4#1
 
 Scenario: implicit-4-2
-	Entry 1 (block 0) - SKIPPED
-	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#implicit-4-2#0#1
-
-	Entry 2 (block 4) - SKIPPED
-	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#implicit-4-2#4#2
+	Entry 1 (block 4) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#implicit-4-2#4#1
 
 Scenario: implicit-5
 	Entry 1 (block 5) - SKIPPED
@@ -66,13 +62,13 @@ Scenario: beta
 	Snapshot ID  : tools_IVGSnapshot_tests_ListScenarioVariants#beta#6#1
 
 Summary
-  Snapshots       : 8 total (6 validated)
+  Snapshots       : 7 total (5 validated)
   Updated         : 0
   Failed          : 0 (diff failures: 0)
 
 # Overall Summary
 
   Processed files : 1 (0 failed)
-  Snapshots       : 8 total (6 validated)
+  Snapshots       : 7 total (5 validated)
   Updated         : 0
   Failed          : 0 (diff failures: 0)

--- a/tools/IVGSnapshot/tests/ListVariableExpansion.ivg
+++ b/tools/IVGSnapshot/tests/ListVariableExpansion.ivg
@@ -1,0 +1,6 @@
+format ivg-3 uses:snapshot-1
+bounds 0,0,16,16
+color=red
+meta snapshot list:[ [ fill $color ] [ pen $color width:2 ] ]
+color=blue
+meta snapshot list:[ [ fill $color ] [ pen $color width:2 ] ]

--- a/tools/IVGSnapshot/tests/ListVariableExpansion.txt
+++ b/tools/IVGSnapshot/tests/ListVariableExpansion.txt
@@ -1,0 +1,54 @@
+tools/IVGSnapshot/tests/ListVariableExpansion.ivg
+  Scenario implicit-1-1 (validate: yes)
+          Entry 1
+                  Block 1 (statement 1), line 4
+                          [ fill $color ]
+  Scenario implicit-1-2 (validate: yes)
+          Entry 1
+          Entry 2
+                  Block 1 (statement 2), line 4
+                          [ pen $color width:2 ]
+  Scenario implicit-2-1 (validate: yes)
+          Entry 1
+                  Block 2 (statement 1), line 6
+                          [ fill $color ]
+  Scenario implicit-2-2 (validate: yes)
+          Entry 1
+          Entry 2
+                  Block 2 (statement 2), line 6
+                          [ pen $color width:2 ]
+# tools/IVGSnapshot/tests/ListVariableExpansion.ivg
+
+Scenario: implicit-1-1
+	Entry 1 (block 1) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-1-1#1#1
+
+Scenario: implicit-1-2
+	Entry 1 (block 0) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-1-2#0#1
+
+	Entry 2 (block 1) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-1-2#1#2
+
+Scenario: implicit-2-1
+	Entry 1 (block 2) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-2-1#2#1
+
+Scenario: implicit-2-2
+	Entry 1 (block 0) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-2-2#0#1
+
+	Entry 2 (block 2) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-2-2#2#2
+
+Summary
+  Snapshots       : 6 total (6 validated)
+  Updated         : 0
+  Failed          : 0 (diff failures: 0)
+
+# Overall Summary
+
+  Processed files : 1 (0 failed)
+  Snapshots       : 6 total (6 validated)
+  Updated         : 0
+  Failed          : 0 (diff failures: 0)

--- a/tools/IVGSnapshot/tests/ListVariableExpansion.txt
+++ b/tools/IVGSnapshot/tests/ListVariableExpansion.txt
@@ -5,7 +5,6 @@ tools/IVGSnapshot/tests/ListVariableExpansion.ivg
                           [ fill $color ]
   Scenario implicit-1-2 (validate: yes)
           Entry 1
-          Entry 2
                   Block 1 (statement 2), line 4
                           [ pen $color width:2 ]
   Scenario implicit-2-1 (validate: yes)
@@ -14,7 +13,6 @@ tools/IVGSnapshot/tests/ListVariableExpansion.ivg
                           [ fill $color ]
   Scenario implicit-2-2 (validate: yes)
           Entry 1
-          Entry 2
                   Block 2 (statement 2), line 6
                           [ pen $color width:2 ]
 # tools/IVGSnapshot/tests/ListVariableExpansion.ivg
@@ -24,31 +22,25 @@ Scenario: implicit-1-1
 	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-1-1#1#1
 
 Scenario: implicit-1-2
-	Entry 1 (block 0) - SKIPPED
-	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-1-2#0#1
-
-	Entry 2 (block 1) - SKIPPED
-	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-1-2#1#2
+	Entry 1 (block 1) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-1-2#1#1
 
 Scenario: implicit-2-1
 	Entry 1 (block 2) - SKIPPED
 	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-2-1#2#1
 
 Scenario: implicit-2-2
-	Entry 1 (block 0) - SKIPPED
-	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-2-2#0#1
-
-	Entry 2 (block 2) - SKIPPED
-	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-2-2#2#2
+	Entry 1 (block 2) - SKIPPED
+	Snapshot ID  : tools_IVGSnapshot_tests_ListVariableExpansion#implicit-2-2#2#1
 
 Summary
-  Snapshots       : 6 total (6 validated)
+  Snapshots       : 4 total (4 validated)
   Updated         : 0
   Failed          : 0 (diff failures: 0)
 
 # Overall Summary
 
   Processed files : 1 (0 failed)
-  Snapshots       : 6 total (6 validated)
+  Snapshots       : 4 total (4 validated)
   Updated         : 0
   Failed          : 0 (diff failures: 0)

--- a/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
+++ b/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
@@ -106,7 +106,7 @@ void TestListScenarioVariants()
         Expect(io.err.empty(), "ListScenarioVariants run should not print to stderr");
         const std::string expected = ReadFile("tools/IVGSnapshot/tests/ListScenarioVariants.txt");
         ExpectEqual(io.out, expected, "ListScenarioVariants list-only output");
-        ExpectEqual(run.totalEntries, static_cast<uint32_t>(8), "ListScenarioVariants entry count");
+        ExpectEqual(run.totalEntries, static_cast<uint32_t>(7), "ListScenarioVariants entry count");
 }
 
 void TestListVariableExpansion()
@@ -119,7 +119,7 @@ void TestListVariableExpansion()
         Expect(io.err.empty(), "ListVariableExpansion run should not print to stderr");
         const std::string expected = ReadFile("tools/IVGSnapshot/tests/ListVariableExpansion.txt");
         ExpectEqual(io.out, expected, "ListVariableExpansion list-only output");
-        ExpectEqual(run.totalEntries, static_cast<uint32_t>(6), "ListVariableExpansion entry count");
+        ExpectEqual(run.totalEntries, static_cast<uint32_t>(4), "ListVariableExpansion entry count");
 }
 
 std::string WriteTemporaryIVG(const std::string &contents)

--- a/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
+++ b/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
@@ -1,324 +1,291 @@
 #define IVG_SNAPSHOT_TESTING 1
 #include "../IVGSnapshot.cpp"
 
+#include <cstdio>
 #include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <sstream>
 
 namespace {
 
-	void Fail(const std::string& message)
-	{
-		std::cerr << "TestSnapshotPlan: " << message << std::endl;
-		std::exit(1);
-	}
-
-	void Expect(bool condition, const std::string& message)
-	{
-		if (!condition) {
-			Fail(message);
-		}
-	}
-
-	void ExpectEqual(uint32_t actual, uint32_t expected, const std::string& label)
-	{
-		if (actual != expected) {
-			std::ostringstream stream;
-			stream << label << " expected " << expected << " but got " << actual;
-			Fail(stream.str());
-		}
-	}
-
-	void ExpectEqual(const String& actual, const std::string& expected, const std::string& label)
-	{
-		if (actual != expected) {
-			std::ostringstream stream;
-			stream << label << " expected '" << expected << "' but got '" << actual << "'";
-			Fail(stream.str());
-		}
-	}
-
-	SnapshotPlan CollectPlan(const std::string& path, const char* source)
-	{
-		String text(source);
-		SnapshotPlan plan(path);
-		std::vector<std::string> includeDirs;
-		SnapshotCollector collector(plan, path, text, includeDirs);
-		STLMapVariables variables;
-		FormatInfo formatInfo;
-		formatInfo.formatId = "meta";
-		formatInfo.uses.insert("snapshot-1");
-		Interpreter interpreter(collector, variables, formatInfo);
-
-		try {
-			interpreter.run(StringRange(text));
-		} catch (Exception& e) {
-			std::ostringstream stream;
-			stream << "unexpected exception: " << e.getError();
-			if (e.hasStatement()) {
-				stream << " near '" << e.getStatement() << "'";
-			}
-			Fail(stream.str());
-		}
-
-		return plan;
-	}
-
-	void TestExplicitScenario()
-	{
-			const char* source =
-			"meta snapshot scenario:one [ set fill red ]\n";
-		SnapshotPlan plan = CollectPlan("explicit.ivg", source);
-
-		const std::vector<SnapshotScenario>& scenarios = plan.getScenarios();
-		const std::vector<SnapshotEntry>& entries = plan.getEntries();
-
-		ExpectEqual(static_cast<uint32_t>(scenarios.size()), 1, "scenario count");
-		ExpectEqual(static_cast<uint32_t>(entries.size()), 1, "entry count");
-
-		const SnapshotScenario& scenario = scenarios[0];
-		ExpectEqual(scenario.name, "one", "scenario name");
-		Expect(scenario.validate, "scenario validate flag should default to true");
-		ExpectEqual(static_cast<uint32_t>(scenario.entryIndices.size()), 1, "scenario entry count");
-
-		const SnapshotEntry& entry = entries[scenario.entryIndices[0]];
-		ExpectEqual(entry.entryOrdinal, 1, "entry ordinal");
-		Expect(entry.validate, "entry validate flag");
-		ExpectEqual(entry.scenarioName, "one", "entry scenario name");
-		ExpectEqual(static_cast<uint32_t>(entry.invocations.size()), 1, "entry invocation count");
-		const SnapshotInvocation& invocation = entry.invocations[0];
-		ExpectEqual(invocation.blockIndex, 1, "invocation block index");
-		ExpectEqual(invocation.statementOrdinal, 1, "invocation statement ordinal");
-		ExpectEqual(invocation.sourceLine, 1, "invocation source line");
-			ExpectEqual(invocation.statements, "[ set fill red ]", "entry statements keep brackets");
-	}
-
-	void TestArrayStatements()
-	{
-			const char* source =
-			"meta snapshot scenario:array list:[ [ do-alpha ] [ do-beta ] [ do-gamma ] ]\n";
-		SnapshotPlan plan = CollectPlan("array.ivg", source);
-
-		const std::vector<SnapshotScenario>& scenarios = plan.getScenarios();
-		const std::vector<SnapshotEntry>& entries = plan.getEntries();
-
-		ExpectEqual(static_cast<uint32_t>(scenarios.size()), 1, "scenario count");
-		ExpectEqual(static_cast<uint32_t>(entries.size()), 3, "entry count");
-
-		const SnapshotScenario& scenario = scenarios[0];
-		ExpectEqual(static_cast<uint32_t>(scenario.entryIndices.size()), 3, "scenario entry count");
-
-		for (uint32_t i = 0; i < 3; ++i) {
-			const SnapshotEntry& entry = entries[scenario.entryIndices[i]];
-			ExpectEqual(entry.entryOrdinal, i + 1, "array entry ordinal");
-			ExpectEqual(static_cast<uint32_t>(entry.invocations.size()), 1, "array invocation count");
-			ExpectEqual(entry.scenarioName, "array", "array scenario name");
-			const SnapshotInvocation& invocation = entry.invocations[0];
-			ExpectEqual(invocation.blockIndex, 1, "array block index");
-			ExpectEqual(invocation.statementOrdinal, i + 1, "array statement ordinal");
-			ExpectEqual(invocation.sourceLine, 1, "array source line");
-			const std::string expected = (i == 0 ? "[ do-alpha ]" : (i == 1 ? "[ do-beta ]" : "[ do-gamma ]"));
-			ExpectEqual(invocation.statements, expected, "array entry statements");
-		}
-	}
-
-	void TestRepeatedScenario()
-	{
-		const char* source =
-		"meta snapshot scenario:smurf list:[ [ do-stuff ] [ do-other-stuff ] ]\n\n"
-		"meta snapshot scenario:smurf list:[ [ do-more-stuff ] [ do-more-other-stuff ] ]\n";
-		SnapshotPlan plan = CollectPlan("repeat.ivg", source);
-
-		const std::vector<SnapshotScenario>& scenarios = plan.getScenarios();
-		const std::vector<SnapshotEntry>& entries = plan.getEntries();
-
-		ExpectEqual(static_cast<uint32_t>(scenarios.size()), 1, "scenario count");
-		ExpectEqual(static_cast<uint32_t>(entries.size()), 2, "entry count");
-
-		const SnapshotScenario& scenario = scenarios[0];
-		ExpectEqual(static_cast<uint32_t>(scenario.entryIndices.size()), 2, "scenario entry count");
-
-		const SnapshotEntry& entryOne = entries[scenario.entryIndices[0]];
-		const SnapshotEntry& entryTwo = entries[scenario.entryIndices[1]];
-		ExpectEqual(static_cast<uint32_t>(entryOne.invocations.size()), 2, "entry one invocation count");
-		ExpectEqual(static_cast<uint32_t>(entryTwo.invocations.size()), 2, "entry two invocation count");
-		ExpectEqual(entryOne.invocations[0].blockIndex, 1, "entry one first block index");
-		ExpectEqual(entryOne.invocations[0].sourceLine, 1, "entry one first block line");
-		ExpectEqual(entryOne.invocations[1].blockIndex, 2, "entry one second block index");
-		ExpectEqual(entryOne.invocations[1].sourceLine, 3, "entry one second block line");
-		ExpectEqual(entryTwo.invocations[0].blockIndex, 1, "entry two first block index");
-		ExpectEqual(entryTwo.invocations[1].blockIndex, 2, "entry two second block index");
-	}
-
-void TestDefaultScenarioNames()
+void Fail(const std::string &message)
 {
-	const char* source =
-		"meta snapshot list:[ [ first ] [ second ] ]\n"
-		"meta snapshot [ third ]\n";
-	SnapshotPlan plan = CollectPlan("implicit.ivg", source);
-
-	const std::vector<SnapshotScenario>& scenarios = plan.getScenarios();
-	const std::vector<SnapshotEntry>& entries = plan.getEntries();
-
-	ExpectEqual(static_cast<uint32_t>(scenarios.size()), 3, "scenario count");
-	ExpectEqual(static_cast<uint32_t>(entries.size()), 3, "entry count");
-
-	ExpectEqual(scenarios[0].name, "implicit-1-1", "first implicit scenario name");
-	ExpectEqual(scenarios[1].name, "implicit-1-2", "second implicit scenario name");
-	ExpectEqual(scenarios[2].name, "implicit-2", "third implicit scenario name");
-
-	ExpectEqual(entries[scenarios[0].entryIndices[0]].entryOrdinal, 1, "first implicit entry ordinal");
-	ExpectEqual(entries[scenarios[1].entryIndices[0]].entryOrdinal, 1, "second implicit entry ordinal");
-	ExpectEqual(entries[scenarios[2].entryIndices[0]].entryOrdinal, 1, "third implicit entry ordinal");
+        std::cerr << "TestSnapshotPlan: " << message << std::endl;
+        std::exit(1);
 }
 
-
-
-void TestSnapshotSourceTags()
+void Expect(bool condition, const std::string &message)
 {
-	const NuXFiles::Path root = NuXFiles::Path::getCurrentDirectoryPath();
-	std::wstring rootWide;
-	try {
-		rootWide = root.getFullPath();
-	} catch (const std::exception&) {
-		Fail("failed to read current directory path");
-	}
-	std::wstring ivgWide = NuXFiles::Path::appendSeparator(rootWide);
-	ivgWide += L"alpha_beta";
-	ivgWide = NuXFiles::Path::appendSeparator(ivgWide);
-	ivgWide += L"gamma_delta.ivg";
-	const std::string ivgPath = pathStringFromWide(ivgWide);
-	const std::string relativeTag = buildSnapshotSourceTag(ivgPath, root);
-	Expect(relativeTag == "alpha__beta_gamma__delta", "root relative snapshot tag should escape underscores");
-
-	NuXFiles::Path parent;
-	if (root.isRoot()) {
-		Fail("cannot run absolute tag test from filesystem root");
-	}
-	try {
-		parent = root.getParent();
-	} catch (const std::exception&) {
-		Fail("failed to resolve parent directory for absolute tag test");
-	}
-	std::wstring outsideWide = NuXFiles::Path::appendSeparator(parent.getFullPath());
-	outsideWide += L"absolute_example.ivg";
-	const std::string outsidePath = pathStringFromWide(outsideWide);
-	const std::string absoluteTag = buildSnapshotSourceTag(outsidePath, root);
-	std::string normalized = outsidePath;
-	for (size_t i = 0; i < normalized.size(); ++i) {
-		if (normalized[i] == '\\') {
-			normalized[i] = '/';
-		}
-	}
-	const size_t dot = normalized.find_last_of('.');
-	if (dot != std::string::npos) {
-		normalized.resize(dot);
-	}
-	Expect(absoluteTag == sanitizeFileComponent(normalized), "outside root should sanitize absolute path");
+        if (!condition) {
+                Fail(message);
+        }
 }
 
+void ExpectEqual(uint32_t actual, uint32_t expected, const std::string &label)
+{
+        if (actual != expected) {
+                std::ostringstream stream;
+                stream << label << " expected " << expected << " but got " << actual;
+                Fail(stream.str());
+        }
+}
 
+void ExpectEqual(const std::string &actual, const std::string &expected, const std::string &label)
+{
+        if (actual != expected) {
+                std::ostringstream stream;
+                stream << label << " expected:\n" << expected << "\nbut got:\n" << actual;
+                Fail(stream.str());
+        }
+}
+
+std::string ReadFile(const std::string &path)
+{
+        std::ifstream input(path.c_str(), std::ios::binary);
+        if (!input.good()) {
+                Fail(std::string("failed to read file: ") + path);
+        }
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        return buffer.str();
+}
+
+struct CapturedIO {
+        std::string out;
+        std::string err;
+};
+
+CapturedIO RunListOnlyTool(const std::string &path, SnapshotRunResult &outRun)
+{
+        CommandLineOptions options;
+        options.listOnly = true;
+
+        SnapshotTotals totals;
+        std::ostringstream outBuffer;
+        std::ostringstream errBuffer;
+
+        std::streambuf *oldOut = std::cout.rdbuf(outBuffer.rdbuf());
+        std::streambuf *oldErr = std::cerr.rdbuf(errBuffer.rdbuf());
+
+        outRun = processFile(options, path);
+        totals.accumulate(outRun);
+        logFileReport(path, outRun);
+        logTotalsSummary(totals);
+
+        std::cout.rdbuf(oldOut);
+        std::cerr.rdbuf(oldErr);
+
+        CapturedIO captured;
+        captured.out = outBuffer.str();
+        captured.err = errBuffer.str();
+        return captured;
+}
+
+void TestListOnlySample()
+{
+        const std::string ivgPath = "tools/IVGSnapshot/tests/ListOnlySample.ivg";
+        SnapshotRunResult run;
+        CapturedIO io = RunListOnlyTool(ivgPath, run);
+
+        Expect(run.exitCode == 0, "ListOnlySample run should succeed");
+        Expect(io.err.empty(), "ListOnlySample run should not print to stderr");
+        const std::string expected = ReadFile("tools/IVGSnapshot/tests/ListOnlySample.txt");
+        ExpectEqual(io.out, expected, "ListOnlySample list-only output");
+        ExpectEqual(run.totalEntries, static_cast<uint32_t>(3), "ListOnlySample entry count");
+        ExpectEqual(run.validatedEntries, static_cast<uint32_t>(3), "ListOnlySample validated count");
+}
+
+void TestListScenarioVariants()
+{
+        const std::string ivgPath = "tools/IVGSnapshot/tests/ListScenarioVariants.ivg";
+        SnapshotRunResult run;
+        CapturedIO io = RunListOnlyTool(ivgPath, run);
+
+        Expect(run.exitCode == 0, "ListScenarioVariants run should succeed");
+        Expect(io.err.empty(), "ListScenarioVariants run should not print to stderr");
+        const std::string expected = ReadFile("tools/IVGSnapshot/tests/ListScenarioVariants.txt");
+        ExpectEqual(io.out, expected, "ListScenarioVariants list-only output");
+        ExpectEqual(run.totalEntries, static_cast<uint32_t>(8), "ListScenarioVariants entry count");
+}
+
+void TestListVariableExpansion()
+{
+        const std::string ivgPath = "tools/IVGSnapshot/tests/ListVariableExpansion.ivg";
+        SnapshotRunResult run;
+        CapturedIO io = RunListOnlyTool(ivgPath, run);
+
+        Expect(run.exitCode == 0, "ListVariableExpansion run should succeed");
+        Expect(io.err.empty(), "ListVariableExpansion run should not print to stderr");
+        const std::string expected = ReadFile("tools/IVGSnapshot/tests/ListVariableExpansion.txt");
+        ExpectEqual(io.out, expected, "ListVariableExpansion list-only output");
+        ExpectEqual(run.totalEntries, static_cast<uint32_t>(6), "ListVariableExpansion entry count");
+}
+
+std::string WriteTemporaryIVG(const std::string &contents)
+{
+        char tempName[L_tmpnam];
+        if (std::tmpnam(tempName) == 0) {
+                Fail("failed to allocate temporary name");
+        }
+        std::string path(tempName);
+        path += ".ivg";
+        std::ofstream file(path.c_str(), std::ios::binary);
+        if (!file.good()) {
+                Fail(std::string("failed to open temporary file: ") + path);
+        }
+        file << contents;
+        file.close();
+        return path;
+}
 
 void TestValidateMismatch()
 {
-	const char* source =
-		"meta snapshot scenario:toggle validate:no list:[ [ draft ] ]\n"
-		"meta snapshot scenario:toggle list:[ [ validate ] ]\n";
+        const char *source =
+                "format ivg-3 uses:snapshot-1\n"
+                "bounds 0,0,16,16\n"
+                "meta snapshot scenario:toggle validate:no [ fill red ]\n"
+                "meta snapshot scenario:toggle validate:yes [ fill blue ]\n";
 
-	String textSource(source);
-	SnapshotPlan plan("mismatch.ivg");
-	std::vector<std::string> includeDirs;
-	SnapshotCollector collector(plan, "mismatch.ivg", textSource, includeDirs);
-	STLMapVariables variables;
-	FormatInfo formatInfo;
-	formatInfo.formatId = "meta";
-	formatInfo.uses.insert("snapshot-1");
-	Interpreter interpreter(collector, variables, formatInfo);
+        const std::string path = WriteTemporaryIVG(source);
 
-	bool caught = false;
-	try {
-		interpreter.run(StringRange(textSource));
-	} catch (Exception& e) {
-		caught = true;
-		Expect(e.getError() == "scenario switches between validate yes/no.", "validate mismatch error message");
-	}
-	Expect(caught, "validate mismatch should throw");
+        CommandLineOptions options;
+        options.listOnly = true;
+
+        std::ostringstream outBuffer;
+        std::ostringstream errBuffer;
+        std::streambuf *oldOut = std::cout.rdbuf(outBuffer.rdbuf());
+        std::streambuf *oldErr = std::cerr.rdbuf(errBuffer.rdbuf());
+        SnapshotRunResult run = processFile(options, path);
+        std::cout.rdbuf(oldOut);
+        std::cerr.rdbuf(oldErr);
+
+        std::remove(path.c_str());
+
+        Expect(run.fileFailed, "validate mismatch should mark file as failed");
+        Expect(run.exitCode == 1, "validate mismatch should set exit code");
+        Expect(run.fileError == "validate flag mismatch for scenario",
+                "validate mismatch should report correct error");
+        Expect(errBuffer.str().find("validate flag mismatch for scenario") != std::string::npos,
+                "validate mismatch should log error to stderr");
+}
+
+void TestSnapshotSourceTags()
+{
+        const NuXFiles::Path root = NuXFiles::Path::getCurrentDirectoryPath();
+        std::wstring rootWide;
+        try {
+                rootWide = root.getFullPath();
+        } catch (const std::exception &) {
+                Fail("failed to read current directory path");
+        }
+        std::wstring ivgWide = NuXFiles::Path::appendSeparator(rootWide);
+        ivgWide += L"alpha_beta";
+        ivgWide = NuXFiles::Path::appendSeparator(ivgWide);
+        ivgWide += L"gamma_delta.ivg";
+        const std::string ivgPath = pathStringFromWide(ivgWide);
+        const std::string relativeTag = buildSnapshotSourceTag(ivgPath, root);
+        Expect(relativeTag == "alpha__beta_gamma__delta",
+                "root relative snapshot tag should escape underscores");
+
+        NuXFiles::Path parent;
+        if (root.isRoot()) {
+                Fail("cannot run absolute tag test from filesystem root");
+        }
+        try {
+                parent = root.getParent();
+        } catch (const std::exception &) {
+                Fail("failed to resolve parent directory for absolute tag test");
+        }
+        std::wstring outsideWide = NuXFiles::Path::appendSeparator(parent.getFullPath());
+        outsideWide += L"absolute_example.ivg";
+        const std::string outsidePath = pathStringFromWide(outsideWide);
+        const std::string absoluteTag = buildSnapshotSourceTag(outsidePath, root);
+        std::string normalized = outsidePath;
+        for (size_t i = 0; i < normalized.size(); ++i) {
+                if (normalized[i] == '\\') {
+                        normalized[i] = '/';
+                }
+        }
+        const size_t dot = normalized.find_last_of('.');
+        if (dot != std::string::npos) {
+                normalized.resize(dot);
+        }
+        Expect(absoluteTag == sanitizeFileComponent(normalized),
+                "outside root should sanitize absolute path");
 }
 
 void TestDraftValidateWorkflow()
 {
-	const char* tempEnv = std::getenv("TMPDIR");
-	const std::string tempRoot = (tempEnv != 0 && tempEnv[0] != '\0') ? std::string(tempEnv) : std::string("/tmp");
+        const char *tempEnv = std::getenv("TMPDIR");
+        const std::string tempRoot =
+                (tempEnv != 0 && tempEnv[0] != '\0') ? std::string(tempEnv) : std::string("/tmp");
 
-	CommandLineOptions options;
-	options.snapshotDir = joinPath(tempRoot, "IVGSnapshotWorkflowTest");
-	options.forceUpdate = false;
+        CommandLineOptions options;
+        options.snapshotDir = joinPath(tempRoot, "IVGSnapshotWorkflowTest");
+        options.forceUpdate = false;
 
-	SnapshotScenario scenario;
-	scenario.name = "workflow";
-	scenario.validate = true;
-	scenario.entryIndices.push_back(0);
+        const String scenarioName("workflow");
+        SnapshotGolden golden("workflow.ivg", "workflow", scenarioName, false, 1, options);
 
-	SnapshotEntry entry;
-	entry.scenarioIndex = 0;
-	entry.entryOrdinal = 1;
-	entry.validate = true;
-	entry.scenarioName = "workflow";
+        SnapshotEntryResult paths;
+        golden.populateResult(paths);
+        Expect(ensureDirectory(extractDirectory(paths.goldenPath)),
+                "create workflow directory");
+        removeFileIfExists(paths.goldenPath);
+        removeFileIfExists(paths.oldPath);
+        removeFileIfExists(paths.actualPath);
+        removeFileIfExists(paths.diffPath);
+        removeFileIfExists(paths.backupPath);
 
-	SnapshotGolden golden("workflow.ivg", "workflow", scenario, entry, options);
+        NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> raster(NuXPixels::IntRect(0, 0, 1, 1));
+        raster.getPixelPointer()[0] = 0xFFFFFFFFu;
 
-	SnapshotEntryResult paths;
-	golden.populateResult(paths);
-	Expect(ensureDirectory(extractDirectory(paths.goldenPath)), "create workflow directory");
-	removeFileIfExists(paths.goldenPath);
-	removeFileIfExists(paths.oldPath);
-	removeFileIfExists(paths.actualPath);
-	removeFileIfExists(paths.diffPath);
-	removeFileIfExists(paths.backupPath);
+        SnapshotEntryResult draftResult;
+        Expect(golden.writeDraft(raster, draftResult), "draft write should succeed");
+        Expect(draftResult.success, "draft result success flag");
+        Expect(draftResult.skipped, "draft result skipped flag");
+        Expect(fileExists(draftResult.oldPath), "old draft file should exist");
+        Expect(!fileExists(draftResult.goldenPath),
+                "golden should not exist after draft");
 
-	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> raster(NuXPixels::IntRect(0, 0, 1, 1));
-	raster.getPixelPointer()[0] = 0xFFFFFFFFu;
+        SnapshotEntryResult validateResult;
+        Expect(golden.validate(raster, false, validateResult),
+                "validate should promote draft");
+        Expect(validateResult.success, "validate result success flag");
+        Expect(validateResult.updated, "validate should mark updated");
+        Expect(!validateResult.skipped, "validate should not be skipped");
+        Expect(fileExists(validateResult.goldenPath),
+                "golden should exist after validate");
+        Expect(!fileExists(validateResult.oldPath),
+                "old draft file should be removed");
+        Expect(validateResult.message.find("promoted draft image") != std::string::npos,
+                "validate should report promotion");
 
-	SnapshotEntryResult draftResult;
-	Expect(golden.writeDraft(raster, draftResult), "draft write should succeed");
-	Expect(draftResult.success, "draft result success flag");
-	Expect(draftResult.skipped, "draft result skipped flag");
-	Expect(fileExists(draftResult.oldPath), "old draft file should exist");
-	Expect(!fileExists(draftResult.goldenPath), "golden should not exist after draft");
+        SnapshotEntryResult secondResult;
+        Expect(golden.validate(raster, false, secondResult),
+                "second validate should compare against golden");
+        Expect(secondResult.success, "second validate success flag");
+        Expect(!secondResult.updated, "second validate should not mark updated");
+        Expect(!secondResult.diffed, "second validate should not diff");
+        Expect(secondResult.message.empty(), "second validate should not report message");
 
-	SnapshotEntryResult validateResult;
-	Expect(golden.validate(raster, false, validateResult), "validate should promote draft");
-	Expect(validateResult.success, "validate result success flag");
-	Expect(validateResult.updated, "validate should mark updated");
-	Expect(!validateResult.skipped, "validate should not be skipped");
-	Expect(fileExists(validateResult.goldenPath), "golden should exist after validate");
-	Expect(!fileExists(validateResult.oldPath), "old draft file should be removed");
-	Expect(validateResult.message.find("promoted draft image") != std::string::npos, "validate should report promotion");
-
-	SnapshotEntryResult secondResult;
-	Expect(golden.validate(raster, false, secondResult), "second validate should compare against golden");
-	Expect(secondResult.success, "second validate success flag");
-	Expect(!secondResult.updated, "second validate should not mark updated");
-	Expect(!secondResult.diffed, "second validate should not diff");
-	Expect(secondResult.message.empty(), "second validate should not report message");
-
-	removeFileIfExists(secondResult.goldenPath);
-	removeFileIfExists(secondResult.actualPath);
-	removeFileIfExists(secondResult.diffPath);
-	removeFileIfExists(secondResult.backupPath);
-	removeFileIfExists(paths.oldPath);
+        removeFileIfExists(secondResult.goldenPath);
+        removeFileIfExists(secondResult.actualPath);
+        removeFileIfExists(secondResult.diffPath);
+        removeFileIfExists(secondResult.backupPath);
+        removeFileIfExists(paths.oldPath);
 }
 
 } // namespace
 
 int main()
-	{
-	TestExplicitScenario();
-	TestArrayStatements();
-	TestRepeatedScenario();
-	TestDefaultScenarioNames();
-	TestSnapshotSourceTags();
-	TestValidateMismatch();
-	TestDraftValidateWorkflow();
-	return 0;
+{
+        TestListOnlySample();
+        TestListScenarioVariants();
+        TestListVariableExpansion();
+        TestValidateMismatch();
+        TestSnapshotSourceTags();
+        TestDraftValidateWorkflow();
+        return 0;
 }

--- a/tools/ivgfiddle/src/ivgfiddle.js
+++ b/tools/ivgfiddle/src/ivgfiddle.js
@@ -392,15 +392,23 @@ const SnapshotController = (function createSnapshotController() {
 			return false;
 		}
 		activeSelection = next;
-		persistedKey = selectionKey(activeSelection);
+		const key = selectionKey(activeSelection);
+		persistedKey = key;
 		Settings.write(STORAGE_KEYS.SNAPSHOT_SELECTION, persistedKey);
 		if (activeSourceSignature) {
 			selectionCache.set(activeSourceSignature, activeSelection);
 		}
+		if (
+			snapshotScenarioSelect &&
+			key !== "" &&
+			snapshotScenarioSelect.value !== key
+		) {
+			snapshotScenarioSelect.value = key;
+		}
 		trace(
 			"Snapshot selection changed to scenario " +
 				next.scenarioIndex +
-				", entry " +
+			", entry " +
 				next.entryOrdinal,
 		);
 		return true;
@@ -432,6 +440,7 @@ const SnapshotController = (function createSnapshotController() {
 		return activeSelection;
 	}
 
+	updateToolbar([]);
 	return {
 		applyRenderResult: applyRenderResult,
 		handleSelectionChange: handleSelectionChange,


### PR DESCRIPTION
## Summary
- keep the snapshot scenario select disabled until the first catalog arrives by calling `updateToolbar([])` during initialization
- when the snapshot selection changes in ivgfiddle, persist the computed key and synchronize the `<select>` element so the toolbar reflects cached choices

## Testing
- node tools/ivgfiddle/tests/ivgfiddle.unit.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f1268637b48332931720590d6117a0