### PR TITLE
Show absolute path for ivgfiddle build output

### DIFF
--- a/tools/ivgfiddle/buildIVGFiddle.cmd
+++ b/tools/ivgfiddle/buildIVGFiddle.cmd
@@ -14,7 +14,9 @@ IF ERRORLEVEL 1 (
 )
 
 IF NOT EXIST "%output%" MKDIR "%output%"
-ECHO Building ivgfiddle in %output% ...
+SET outputDisplay=%output%
+FOR %%I IN ("%output%") DO SET outputDisplay=%%~fI
+ECHO Building ivgfiddle in %outputDisplay% ...
 "emcc" -sWASM=1 -sNO_DISABLE_EXCEPTION_CATCHING -sTOTAL_MEMORY=67108864 -sSINGLE_FILE -sMODULARIZE=1 -sEXPORT_ES6=0 -sENVIRONMENT=web,node -sEXPORTED_FUNCTIONS=_rasterizeIVG,_deallocatePixels,_malloc,_free -sEXPORTED_RUNTIME_METHODS=ccall,cwrap,lengthBytesUTF8,stringToUTF8,FS,HEAPU8,HEAPU32,HEAPF32 --embed-file "%fonts%\sans-serif.ivgfont@sans-serif.ivgfont" --embed-file "%fonts%\serif.ivgfont@serif.ivgfont" --embed-file "%fonts%\code.ivgfont@code.ivgfont" --embed-file "%src%\demoSource.ivg@demoSource.ivg" -s "BINARYEN_METHOD='native-wasm'" -DNUXPIXELS_SIMD=0 -DNDEBUG -std=c++03 -fexceptions -O3 -I../../externals/ "%src%\rasterizeIVG.cpp" ../../src/IVG.cpp ../../src/IMPD.cpp ../../externals/NuX/NuXPixels.cpp -o "%output%\rasterizeIVG.js" || GOTO error
 
 COPY "%src%\ivgfiddle.html" "%src%\ivgfiddle.js" "%src%\setupModule.js" "%src%\previewShared.js" "%output%" >NUL

--- a/tools/ivgfiddle/buildIVGFiddle.sh
+++ b/tools/ivgfiddle/buildIVGFiddle.sh
@@ -13,7 +13,8 @@ if ! command -v emcc >/dev/null 2>&1; then
 	fi
 fi
 mkdir -p "$output"
-echo "Building ivgfiddle in $output ..."
+output_abs="$(cd "$output" && pwd)"
+echo "Building ivgfiddle in $output_abs ..."
 emcc -sWASM=1 -sNO_DISABLE_EXCEPTION_CATCHING -sTOTAL_MEMORY=67108864 -sSINGLE_FILE -sMODULARIZE=1 -sEXPORT_ES6=0 -sENVIRONMENT=web,node -sEXPORTED_FUNCTIONS=_rasterizeIVG,_deallocatePixels,_malloc,_free -sEXPORTED_RUNTIME_METHODS=ccall,cwrap,lengthBytesUTF8,stringToUTF8,FS,HEAPU8,HEAPU32,HEAPF32 --embed-file "$fonts/sans-serif.ivgfont@sans-serif.ivgfont" --embed-file "$fonts/serif.ivgfont@serif.ivgfont" --embed-file "$fonts/code.ivgfont@code.ivgfont" --embed-file "$src/demoSource.ivg@demoSource.ivg" -s "BINARYEN_METHOD='native-wasm'" -DNUXPIXELS_SIMD=0 -DNDEBUG -std=c++03 -fexceptions -O3 -I../../externals/ "$src/rasterizeIVG.cpp" ../../src/IVG.cpp ../../src/IMPD.cpp ../../externals/NuX/NuXPixels.cpp -o "$output/rasterizeIVG.js"
 cp "$src/ivgfiddle.html" "$src/ivgfiddle.js" "$src/setupModule.js" "$src/previewShared.js" "$output"
 mkdir -p "$output/ace"


### PR DESCRIPTION
## Summary
- report the absolute output directory in `buildIVGFiddle.sh`
- mirror the absolute-path message in `buildIVGFiddle.cmd`

## Testing
- `timeout 600 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68f7865c02c083329c2907b283bae230