### PR TITLE
Handle exceptions in IVGSnapshot parallel loop

### DIFF
--- a/docs/IVGSnapshot.md
+++ b/docs/IVGSnapshot.md
@@ -27,6 +27,16 @@ Authors can record either a single ImpD block (`meta snapshot [ set fill red ]`)
 ### Scenario Grouping and Entry Ordinals
 Snapshot plans organize data as scenarios containing ordered entries. Every directive receives a monotonically increasing `blockIndex`, and each entry inside a scenario carries its own `entryOrdinal`. Implicit scenarios increment ordinals sequentially to preserve discovery order; explicit scenarios reuse their ordinals when additional directives append invocations to an existing entry. `SnapshotProgress` normalizes names and ordinals so that unlabeled lists surface as `unlabeled-<n>` variants while preserving the original block sequencing. When jobs are scheduled, the tool composes stable identifiers using the sanitized snapshot base, scenario name, block index, and entry ordinal (for example `controls#dark-mode#2#1`).
 
+### Terminology used in list output
+The list-only fixtures and `--list-only` output reuse a small set of names that map directly to runtime data structures:
+
+- **Scenario entry** – A single item inside a scenario, identified by the ordinal tracked in `SeenScenario::maxOrdinal`. Each entry lines up with what the executor considers a distinct choice in the preview UI and a unit of work for validation. Scenario entries can originate from a standalone `meta snapshot` directive or from an element inside a `list:[ ... ]` directive.
+- **Snapshot block** – The enclosing `meta snapshot-1 { ... }` section encountered while replaying the IVG. `SnapshotRoundState::blockOrdinalCursor` increments each time the interpreter enters a new block, so the reported number mirrors the order in which the directives appear in the source file.
+- **Block entry** – The position of a particular entry within the snapshot block that recorded it. When a `list:[ ... ]` contains multiple bodies, the executor visits them sequentially and stamps the first as block entry `#1`, the second as `#2`, and so on. Singleton directives always report block entry `#1`.
+- **Statement body** – The literal ImpD code captured for that entry. `SnapshotInvocation::statements` stores the exact text between the brackets, which the list output indents beneath the block information.
+
+These labels intentionally align with the field names in `SnapshotInvocation` so maintainers can cross-reference logs with the underlying plan representation. No additional terminology is used beyond the scenario name itself.
+
 ## Naming and Output Paths
 IVGSnapshot derives the output stem by normalizing the IVG path relative to `--root-dir` (default: the current working directory). Path separators collapse to single underscores while existing underscores are doubled to avoid collisions. For each entry the tool produces:
 

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -2514,39 +2514,44 @@ static bool readFile(const std::string &path, String &contents) {
 
 static void printScenarioListing(const std::string &path,
                                                             const SnapshotProgress &progress) {
-        std::cout << path << std::endl;
-	const std::vector<SeenScenario> &scenarios = progress.getSeenScenarios();
-	for (size_t i = 0; i < scenarios.size(); ++i) {
-		const SeenScenario &scenario = scenarios[i];
-		std::cout << "  Scenario " << stringFromIMPD(scenario.name)
-		          << " (validate: " << (scenario.validate ? "yes" : "no")
-		          << ")" << std::endl;
-		for (uint32_t ordinal = 1; ordinal <= scenario.maxOrdinal; ++ordinal) {
-			if (!scenario.isProcessed(ordinal)) {
-				continue;
-			}
+        static const char scenarioIndent[] = "  ";
+        static const char entryIndent[] = "    ";
+        static const char blockIndent[] = "      ";
+        static const char snippetIndent[] = "        ";
 
-			std::cout << "          Entry " << ordinal << std::endl;
-			const ScenarioEntryMetadata *metadata =
-			        scenario.getEntryMetadata(ordinal);
-			if (metadata == 0) {
+        std::cout << path << std::endl;
+        const std::vector<SeenScenario> &scenarios = progress.getSeenScenarios();
+        for (size_t i = 0; i < scenarios.size(); ++i) {
+                const SeenScenario &scenario = scenarios[i];
+                std::cout << scenarioIndent << "Scenario "
+                          << stringFromIMPD(scenario.name)
+                          << " (validate: " << (scenario.validate ? "yes" : "no")
+                          << ")" << std::endl;
+                for (uint32_t ordinal = 1; ordinal <= scenario.maxOrdinal; ++ordinal) {
+                        if (!scenario.isProcessed(ordinal)) {
+                                continue;
+                        }
+
+                        std::cout << entryIndent << "Entry #" << ordinal << std::endl;
+                        const ScenarioEntryMetadata *metadata =
+                                scenario.getEntryMetadata(ordinal);
+                        if (metadata == 0) {
                                 continue;
                         }
 
                         for (size_t k = 0; k < metadata->invocations.size(); ++k) {
                                 const SnapshotInvocation &invocation =
                                         metadata->invocations[k];
-                                std::cout << "                  Block " << invocation.blockIndex
-                                                  << " (statement " << invocation.statementOrdinal
-                                                  << "), line " << invocation.sourceLine
-                                                  << std::endl;
+                                std::cout << blockIndent << "Block #" << invocation.blockIndex
+                                                  << ", statement #" << invocation.statementOrdinal
+                                                  << " (source line " << invocation.sourceLine
+                                                  << ")" << std::endl;
 
                                 std::istringstream snippet(
                                         stringFromIMPD(invocation.statements));
                                 std::string line;
                                 while (std::getline(snippet, line)) {
-                                        std::cout << "                          " << line
-                                                          << std::endl;
+                                        std::cout << snippetIndent << line << std::endl;
                                 }
                         }
                 }

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -107,7 +107,7 @@ class CachedDocument {
 struct SnapshotInvocation {
         uint32_t blockIndex;
         uint32_t sourceLine;
-        uint32_t statementOrdinal;
+        uint32_t entryOrdinal;
         String statements;
 };
 struct SnapshotRoundState {
@@ -143,11 +143,11 @@ struct SnapshotRoundState {
         }
 
         SnapshotInvocation *findInvocation(uint32_t blockIndex,
-                                                                  uint32_t statementOrdinal) {
+                                                                  uint32_t entryOrdinal) {
                 for (size_t i = 0; i < invocations.size(); ++i) {
                         SnapshotInvocation &invocation = invocations[i];
                         if (invocation.blockIndex == blockIndex &&
-                                invocation.statementOrdinal == statementOrdinal) {
+                                invocation.entryOrdinal == entryOrdinal) {
                                 return &invocation;
                         }
                 }
@@ -155,12 +155,12 @@ struct SnapshotRoundState {
         }
 
         void recordInvocation(uint32_t blockIndex, uint32_t sourceLine,
-                                                      uint32_t statementOrdinal,
+                                                      uint32_t entryOrdinal,
                                                       const String &statementBody) {
                 SnapshotInvocation invocation;
                 invocation.blockIndex = blockIndex;
                 invocation.sourceLine = sourceLine;
-                invocation.statementOrdinal = statementOrdinal;
+                invocation.entryOrdinal = entryOrdinal;
                 invocation.statements = statementBody;
                 invocations.push_back(invocation);
         }
@@ -2224,7 +2224,7 @@ scenarioLabel, blockOrdinal, entryOrdinal, scenarioOrdinal,
                                 std::cout << sourcePath << ": scenario "
                                                   << round->scenario << " entry "
                                                   << round->entryOrdinal << " block "
-                                                  << blockOrdinal << " (statement "
+                                                  << blockOrdinal << " (block entry "
                                                   << entryOrdinal << ")" << std::endl;
                         }
 
@@ -2532,7 +2532,8 @@ static void printScenarioListing(const std::string &path,
                                 continue;
                         }
 
-                        std::cout << entryIndent << "Entry #" << ordinal << std::endl;
+                        std::cout << entryIndent << "Scenario entry #" << ordinal
+                                  << std::endl;
                         const ScenarioEntryMetadata *metadata =
                                 scenario.getEntryMetadata(ordinal);
                         if (metadata == 0) {
@@ -2542,10 +2543,13 @@ static void printScenarioListing(const std::string &path,
                         for (size_t k = 0; k < metadata->invocations.size(); ++k) {
                                 const SnapshotInvocation &invocation =
                                         metadata->invocations[k];
-                                std::cout << blockIndent << "Block #" << invocation.blockIndex
-                                                  << ", statement #" << invocation.statementOrdinal
-                                                  << " (source line " << invocation.sourceLine
-                                                  << ")" << std::endl;
+                                std::cout << blockIndent << "Snapshot block #"
+                                                  << invocation.blockIndex
+                                                  << " (block entry #"
+                                                  << invocation.entryOrdinal
+                                                  << ", source line "
+                                                  << invocation.sourceLine << ")"
+                                                  << std::endl;
 
                                 std::istringstream snippet(
                                         stringFromIMPD(invocation.statements));

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -2786,108 +2786,94 @@ int main(int argc, char **argv) {
         const size_t fileCount = options.ivgPaths.size();
         const uint32_t threadCount = determineThreadCount(options, fileCount);
 
-        if (threadCount <= 1) {
-                for (size_t i = 0; i < fileCount; ++i) {
-                        const std::string &path = options.ivgPaths[i];
-                        SnapshotRunResult run = processFile(options, path);
-                        totals.accumulate(run);
-                        logFileReport(path, run);
-                        if (run.exitCode != 0 || run.fileFailed) {
-                                if (exitCode == 0) {
-                                        exitCode = (run.exitCode != 0 ? run.exitCode : 1);
-                                }
-                                if (options.exitOnFirstFailure) {
-                                        break;
-                                }
-                        }
-                }
-	} else {
-		std::vector<SnapshotRunResult> runs(fileCount);
-		std::vector<uint8_t> processed(fileCount, 0);
-		std::atomic<bool> stop(false);
+	std::vector<SnapshotRunResult> runs(fileCount);
+	std::vector<uint8_t> processed(fileCount, 0);
+	std::atomic<bool> stop(false);
 
-		auto loop = [&options, &runs, &processed, &stop](int index,
-				int iterationCount, int threadIndex) -> bool {
-			(void)iterationCount;
-			(void)threadIndex;
+	auto loop = [&options, &runs, &processed, &stop](int index,
+			int iterationCount, int threadIndex) -> bool {
+		(void)iterationCount;
+		(void)threadIndex;
 
-			if (stop.load()) {
-				return false;
-			}
+		if (stop.load()) {
+			return false;
+		}
 
-			const size_t fileIndex = static_cast<size_t>(index);
-			if (fileIndex >= options.ivgPaths.size()) {
-				return false;
-			}
+		const size_t fileIndex = static_cast<size_t>(index);
+		if (fileIndex >= options.ivgPaths.size()) {
+			return false;
+		}
 
-			const std::string &path = options.ivgPaths[fileIndex];
-			SnapshotRunResult run;
-			bool shouldStop = false;
+		const std::string &path = options.ivgPaths[fileIndex];
+		SnapshotRunResult run;
+		bool shouldStop = false;
 
-			try {
-				run = processFile(options, path);
-				if (options.exitOnFirstFailure &&
+		try {
+			run = processFile(options, path);
+			if (options.exitOnFirstFailure &&
 					(run.exitCode != 0 || run.fileFailed)) {
-					shouldStop = true;
-				}
-			} catch (Exception &e) {
-				std::ostringstream message;
-				message << path << ": " << e.getError();
-				if (e.hasStatement()) {
-					message << " near \"" << e.getStatement() << "\"";
-				}
-				run.fileFailed = true;
-				run.exitCode = 1;
-				run.fileError = message.str();
-				std::cerr << message.str() << std::endl;
-				shouldStop = options.exitOnFirstFailure;
-			} catch (std::exception &e) {
-				run.fileFailed = true;
-				run.exitCode = 1;
-				run.fileError = e.what();
-				std::cerr << path << ": " << e.what() << std::endl;
-				shouldStop = options.exitOnFirstFailure;
-			} catch (...) {
-				run.fileFailed = true;
-				run.exitCode = 1;
-				run.fileError = "unknown exception";
-				std::cerr << path << ": unknown exception" << std::endl;
-				shouldStop = options.exitOnFirstFailure;
+				shouldStop = true;
 			}
-
-			runs[fileIndex] = run;
-			processed[fileIndex] = 1;
-
-			if (shouldStop) {
-				stop.store(true);
-				return false;
+		} catch (Exception &e) {
+			std::ostringstream message;
+			message << path << ": " << e.getError();
+			if (e.hasStatement()) {
+				message << " near \"" << e.getStatement() << "\"";
 			}
+			run.fileFailed = true;
+			run.exitCode = 1;
+			run.fileError = message.str();
+			std::cerr << message.str() << std::endl;
+			shouldStop = options.exitOnFirstFailure;
+		} catch (std::exception &e) {
+			run.fileFailed = true;
+			run.exitCode = 1;
+			run.fileError = e.what();
+			std::cerr << path << ": " << e.what() << std::endl;
+			shouldStop = options.exitOnFirstFailure;
+		} catch (...) {
+			run.fileFailed = true;
+			run.exitCode = 1;
+			run.fileError = "unknown exception";
+			std::cerr << path << ": unknown exception" << std::endl;
+			shouldStop = options.exitOnFirstFailure;
+		}
 
-			return true;
-		};
+		runs[fileIndex] = run;
+		processed[fileIndex] = 1;
 
+		if (shouldStop) {
+			stop.store(true);
+			return false;
+		}
+
+		return true;
+	};
+
+	if (fileCount > 0) {
 		NuXThreads::runLoopInParallel(static_cast<int>(fileCount), loop,
-			static_cast<int>(threadCount));
+				static_cast<int>(threadCount));
+	}
 
-		for (size_t i = 0; i < fileCount; ++i) {
-			if (!processed[i]) {
-				continue;
+	for (size_t i = 0; i < fileCount; ++i) {
+		if (!processed[i]) {
+			continue;
+		}
+
+		const std::string &path = options.ivgPaths[i];
+		SnapshotRunResult &run = runs[i];
+		totals.accumulate(run);
+		logFileReport(path, run);
+		if (run.exitCode != 0 || run.fileFailed) {
+			if (exitCode == 0) {
+				exitCode = (run.exitCode != 0 ? run.exitCode : 1);
 			}
-
-			const std::string &path = options.ivgPaths[i];
-			SnapshotRunResult &run = runs[i];
-			totals.accumulate(run);
-			logFileReport(path, run);
-			if (run.exitCode != 0 || run.fileFailed) {
-				if (exitCode == 0) {
-					exitCode = (run.exitCode != 0 ? run.exitCode : 1);
-				}
-				if (options.exitOnFirstFailure) {
-					break;
-				}
+			if (options.exitOnFirstFailure) {
+				break;
 			}
 		}
 	}
+
         logTotalsSummary(totals);
         return exitCode;
 }

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -1413,7 +1413,8 @@ static void logFileReport(const std::string &path, const SnapshotRunResult &run)
 	printSummaryLine("Snapshots", snapshotLine.str());
 	printSummaryLine("Updated", Interpreter::toString(static_cast<int32_t>(run.updatedEntries)));
 	std::ostringstream failedLine;
-	failedLine << run.failedEntries << " (diff failures: " << run.diffFailures << ')';
+	failedLine << run.failedEntries << " snapshots (diff failures: "
+			<< run.diffFailures << ')';
 	printSummaryLine("Failed", failedLine.str());
 	std::cout << std::endl;
 }
@@ -1421,8 +1422,8 @@ static void logFileReport(const std::string &path, const SnapshotRunResult &run)
 static void logTotalsSummary(const SnapshotTotals &totals) {
 	std::cout << "# Overall Summary" << std::endl << std::endl;
 	std::ostringstream processedLine;
-	processedLine << totals.filesProcessed << " (" << totals.failedFiles
-				  << " failed)";
+	processedLine << totals.filesProcessed << " total (" << totals.failedFiles
+			<< " files reported failures)";
 	printSummaryLine("Processed files", processedLine.str());
 	std::ostringstream snapshotLine;
 	snapshotLine << totals.totalEntries << " total (" << totals.validatedEntries
@@ -1430,8 +1431,8 @@ static void logTotalsSummary(const SnapshotTotals &totals) {
 	printSummaryLine("Snapshots", snapshotLine.str());
 	printSummaryLine("Updated", Interpreter::toString(static_cast<int32_t>(totals.updatedEntries)));
 	std::ostringstream failedLine;
-	failedLine << totals.failedEntries << " (diff failures: " << totals.diffFailures
-			   << ')';
+	failedLine << totals.failedEntries << " snapshots (diff failures: "
+			<< totals.diffFailures << ')';
 	printSummaryLine("Failed", failedLine.str());
 }
 static bool

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -34,7 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <deque>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -42,7 +41,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <locale>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -2803,73 +2801,93 @@ int main(int argc, char **argv) {
                                 }
                         }
                 }
-        } else {
-                std::vector<SnapshotRunResult> runs(fileCount);
-                std::vector<uint8_t> processed(fileCount, 0);
-                std::deque<size_t> pending;
-                for (size_t i = 0; i < fileCount; ++i) {
-                        pending.push_back(i);
-                }
+	} else {
+		std::vector<SnapshotRunResult> runs(fileCount);
+		std::vector<uint8_t> processed(fileCount, 0);
+		std::atomic<bool> stop(false);
 
-                std::mutex queueMutex;
-                std::atomic<bool> stop(false);
-                std::vector<std::thread> workers;
-                workers.reserve(threadCount);
+		auto loop = [&options, &runs, &processed, &stop](int index,
+				int iterationCount, int threadIndex) -> bool {
+			(void)iterationCount;
+			(void)threadIndex;
 
-                for (uint32_t t = 0; t < threadCount; ++t) {
-                        workers.push_back(std::thread([&options, &pending, &queueMutex, &stop,
-                                                                                 &runs, &processed]() {
-                                while (true) {
-                                        if (stop.load()) {
-                                                break;
-                                        }
+			if (stop.load()) {
+				return false;
+			}
 
-                                        size_t index = static_cast<size_t>(-1);
-                                        {
-                                                std::lock_guard<std::mutex> lock(queueMutex);
-                                                if (stop.load() || pending.empty()) {
-                                                        break;
-                                                }
-                                                index = pending.front();
-                                                pending.pop_front();
-                                        }
+			const size_t fileIndex = static_cast<size_t>(index);
+			if (fileIndex >= options.ivgPaths.size()) {
+				return false;
+			}
 
-                                        const std::string &path = options.ivgPaths[index];
-                                        SnapshotRunResult run = processFile(options, path);
-                                        runs[index] = run;
-                                        processed[index] = 1;
+			const std::string &path = options.ivgPaths[fileIndex];
+			SnapshotRunResult run;
+			bool shouldStop = false;
 
-                                        if (options.exitOnFirstFailure &&
-                                                (run.exitCode != 0 || run.fileFailed)) {
-                                                stop.store(true);
-                                        }
-                                }
-                        }));
-                }
+			try {
+				run = processFile(options, path);
+				if (options.exitOnFirstFailure &&
+					(run.exitCode != 0 || run.fileFailed)) {
+					shouldStop = true;
+				}
+			} catch (Exception &e) {
+				std::ostringstream message;
+				message << path << ": " << e.getError();
+				if (e.hasStatement()) {
+					message << " near \"" << e.getStatement() << "\"";
+				}
+				run.fileFailed = true;
+				run.exitCode = 1;
+				run.fileError = message.str();
+				std::cerr << message.str() << std::endl;
+				shouldStop = options.exitOnFirstFailure;
+			} catch (std::exception &e) {
+				run.fileFailed = true;
+				run.exitCode = 1;
+				run.fileError = e.what();
+				std::cerr << path << ": " << e.what() << std::endl;
+				shouldStop = options.exitOnFirstFailure;
+			} catch (...) {
+				run.fileFailed = true;
+				run.exitCode = 1;
+				run.fileError = "unknown exception";
+				std::cerr << path << ": unknown exception" << std::endl;
+				shouldStop = options.exitOnFirstFailure;
+			}
 
-                for (size_t i = 0; i < workers.size(); ++i) {
-                        workers[i].join();
-                }
+			runs[fileIndex] = run;
+			processed[fileIndex] = 1;
 
-                for (size_t i = 0; i < fileCount; ++i) {
-                        if (!processed[i]) {
-                                continue;
-                        }
+			if (shouldStop) {
+				stop.store(true);
+				return false;
+			}
 
-                        const std::string &path = options.ivgPaths[i];
-                        SnapshotRunResult &run = runs[i];
-                        totals.accumulate(run);
-                        logFileReport(path, run);
-                        if (run.exitCode != 0 || run.fileFailed) {
-                                if (exitCode == 0) {
-                                        exitCode = (run.exitCode != 0 ? run.exitCode : 1);
-                                }
-                                if (options.exitOnFirstFailure) {
-                                        break;
-                                }
-                        }
-                }
-        }
+			return true;
+		};
+
+		NuXThreads::runLoopInParallel(static_cast<int>(fileCount), loop,
+			static_cast<int>(threadCount));
+
+		for (size_t i = 0; i < fileCount; ++i) {
+			if (!processed[i]) {
+				continue;
+			}
+
+			const std::string &path = options.ivgPaths[i];
+			SnapshotRunResult &run = runs[i];
+			totals.accumulate(run);
+			logFileReport(path, run);
+			if (run.exitCode != 0 || run.fileFailed) {
+				if (exitCode == 0) {
+					exitCode = (run.exitCode != 0 ? run.exitCode : 1);
+				}
+				if (options.exitOnFirstFailure) {
+					break;
+				}
+			}
+		}
+	}
         logTotalsSummary(totals);
         return exitCode;
 }

--- a/tools/IVGSnapshot/tests/ListOnlySample.txt
+++ b/tools/IVGSnapshot/tests/ListOnlySample.txt
@@ -1,15 +1,15 @@
 tools/IVGSnapshot/tests/ListOnlySample.ivg
   Scenario smurf (validate: yes)
-          Entry 1
-                  Block 1 (statement 1), line 3
-                          [ fill red ]
-          Entry 2
-                  Block 1 (statement 2), line 3
-                          [ pen blue width:2 ]
+    Entry #1
+      Block #1, statement #1 (source line 3)
+        [ fill red ]
+    Entry #2
+      Block #1, statement #2 (source line 3)
+        [ pen blue width:2 ]
   Scenario implicit-2 (validate: yes)
-          Entry 1
-                  Block 2 (statement 1), line 4
-                          [ pen red dash:4 width:2 ]
+    Entry #1
+      Block #2, statement #1 (source line 4)
+        [ pen red dash:4 width:2 ]
 # tools/IVGSnapshot/tests/ListOnlySample.ivg
 
 Scenario: smurf #0

--- a/tools/IVGSnapshot/tests/ListOnlySample.txt
+++ b/tools/IVGSnapshot/tests/ListOnlySample.txt
@@ -1,14 +1,14 @@
 tools/IVGSnapshot/tests/ListOnlySample.ivg
   Scenario smurf (validate: yes)
-    Entry #1
-      Block #1, statement #1 (source line 3)
+    Scenario entry #1
+      Snapshot block #1 (block entry #1, source line 3)
         [ fill red ]
-    Entry #2
-      Block #1, statement #2 (source line 3)
+    Scenario entry #2
+      Snapshot block #1 (block entry #2, source line 3)
         [ pen blue width:2 ]
   Scenario implicit-2 (validate: yes)
-    Entry #1
-      Block #2, statement #1 (source line 4)
+    Scenario entry #1
+      Snapshot block #2 (block entry #1, source line 4)
         [ pen red dash:4 width:2 ]
 # tools/IVGSnapshot/tests/ListOnlySample.ivg
 

--- a/tools/IVGSnapshot/tests/ListOnlySample.txt
+++ b/tools/IVGSnapshot/tests/ListOnlySample.txt
@@ -27,11 +27,11 @@ Scenario: unlabeled-1
 Summary
   Snapshots       : 3 total (3 validated)
   Updated         : 0
-  Failed          : 0 (diff failures: 0)
+  Failed          : 0 snapshots (diff failures: 0)
 
 # Overall Summary
 
-  Processed files : 1 (0 failed)
+  Processed files : 1 total (0 files reported failures)
   Snapshots       : 3 total (3 validated)
   Updated         : 0
-  Failed          : 0 (diff failures: 0)
+  Failed          : 0 snapshots (diff failures: 0)

--- a/tools/IVGSnapshot/tests/ListScenarioVariants.txt
+++ b/tools/IVGSnapshot/tests/ListScenarioVariants.txt
@@ -65,11 +65,11 @@ Scenario: beta
 Summary
   Snapshots       : 7 total (5 validated)
   Updated         : 0
-  Failed          : 0 (diff failures: 0)
+  Failed          : 0 snapshots (diff failures: 0)
 
 # Overall Summary
 
-  Processed files : 1 (0 failed)
+  Processed files : 1 total (0 files reported failures)
   Snapshots       : 7 total (5 validated)
   Updated         : 0
-  Failed          : 0 (diff failures: 0)
+  Failed          : 0 snapshots (diff failures: 0)

--- a/tools/IVGSnapshot/tests/ListScenarioVariants.txt
+++ b/tools/IVGSnapshot/tests/ListScenarioVariants.txt
@@ -1,37 +1,37 @@
 tools/IVGSnapshot/tests/ListScenarioVariants.ivg
   Scenario alpha (validate: yes)
-          Entry 1
-                  Block 1 (statement 1), line 3
-                          [ fill red ]
-                  Block 2 (statement 1), line 4
-                          [ fill #ffd700 ]
-          Entry 2
-                  Block 1 (statement 2), line 3
-                          [ pen blue width:2 ]
-                  Block 2 (statement 2), line 4
-                          [ pen green width:3 ]
+    Entry #1
+      Block #1, statement #1 (source line 3)
+        [ fill red ]
+      Block #2, statement #1 (source line 4)
+        [ fill #ffd700 ]
+    Entry #2
+      Block #1, statement #2 (source line 3)
+        [ pen blue width:2 ]
+      Block #2, statement #2 (source line 4)
+        [ pen green width:3 ]
   Scenario implicit-3 (validate: no)
-          Entry 1
-                  Block 3 (statement 1), line 5
-                          [ pen black dash:4 width:2 ]
+    Entry #1
+      Block #3, statement #1 (source line 5)
+        [ pen black dash:4 width:2 ]
   Scenario implicit-4-1 (validate: yes)
-          Entry 1
-                  Block 4 (statement 1), line 6
-                          [ fill #112233 ]
+    Entry #1
+      Block #4, statement #1 (source line 6)
+        [ fill #112233 ]
   Scenario implicit-4-2 (validate: yes)
-          Entry 1
-                  Block 4 (statement 2), line 6
-                          [ fill #445566 ]
+    Entry #1
+      Block #4, statement #2 (source line 6)
+        [ fill #445566 ]
   Scenario implicit-5 (validate: yes)
-          Entry 1
-                  Block 5 (statement 1), line 7
-                          [ fill #778899 ]
+    Entry #1
+      Block #5, statement #1 (source line 7)
+        [ fill #778899 ]
   Scenario beta (validate: no)
-          Entry 1
-                  Block 6 (statement 1), line 8
-                          [ fill black ]
-                  Block 7 (statement 1), line 9
-                          [ fill gray ]
+    Entry #1
+      Block #6, statement #1 (source line 8)
+        [ fill black ]
+      Block #7, statement #1 (source line 9)
+        [ fill gray ]
 # tools/IVGSnapshot/tests/ListScenarioVariants.ivg
 
 Scenario: alpha #0

--- a/tools/IVGSnapshot/tests/ListScenarioVariants.txt
+++ b/tools/IVGSnapshot/tests/ListScenarioVariants.txt
@@ -1,36 +1,36 @@
 tools/IVGSnapshot/tests/ListScenarioVariants.ivg
   Scenario alpha (validate: yes)
-    Entry #1
-      Block #1, statement #1 (source line 3)
+    Scenario entry #1
+      Snapshot block #1 (block entry #1, source line 3)
         [ fill red ]
-      Block #2, statement #1 (source line 4)
+      Snapshot block #2 (block entry #1, source line 4)
         [ fill #ffd700 ]
-    Entry #2
-      Block #1, statement #2 (source line 3)
+    Scenario entry #2
+      Snapshot block #1 (block entry #2, source line 3)
         [ pen blue width:2 ]
-      Block #2, statement #2 (source line 4)
+      Snapshot block #2 (block entry #2, source line 4)
         [ pen green width:3 ]
   Scenario implicit-3 (validate: no)
-    Entry #1
-      Block #3, statement #1 (source line 5)
+    Scenario entry #1
+      Snapshot block #3 (block entry #1, source line 5)
         [ pen black dash:4 width:2 ]
   Scenario implicit-4-1 (validate: yes)
-    Entry #1
-      Block #4, statement #1 (source line 6)
+    Scenario entry #1
+      Snapshot block #4 (block entry #1, source line 6)
         [ fill #112233 ]
   Scenario implicit-4-2 (validate: yes)
-    Entry #1
-      Block #4, statement #2 (source line 6)
+    Scenario entry #1
+      Snapshot block #4 (block entry #2, source line 6)
         [ fill #445566 ]
   Scenario implicit-5 (validate: yes)
-    Entry #1
-      Block #5, statement #1 (source line 7)
+    Scenario entry #1
+      Snapshot block #5 (block entry #1, source line 7)
         [ fill #778899 ]
   Scenario beta (validate: no)
-    Entry #1
-      Block #6, statement #1 (source line 8)
+    Scenario entry #1
+      Snapshot block #6 (block entry #1, source line 8)
         [ fill black ]
-      Block #7, statement #1 (source line 9)
+      Snapshot block #7 (block entry #1, source line 9)
         [ fill gray ]
 # tools/IVGSnapshot/tests/ListScenarioVariants.ivg
 

--- a/tools/IVGSnapshot/tests/ListVariableExpansion.txt
+++ b/tools/IVGSnapshot/tests/ListVariableExpansion.txt
@@ -1,20 +1,20 @@
 tools/IVGSnapshot/tests/ListVariableExpansion.ivg
   Scenario implicit-1-1 (validate: yes)
-          Entry 1
-                  Block 1 (statement 1), line 4
-                          [ fill $color ]
+    Entry #1
+      Block #1, statement #1 (source line 4)
+        [ fill $color ]
   Scenario implicit-1-2 (validate: yes)
-          Entry 1
-                  Block 1 (statement 2), line 4
-                          [ pen $color width:2 ]
+    Entry #1
+      Block #1, statement #2 (source line 4)
+        [ pen $color width:2 ]
   Scenario implicit-2-1 (validate: yes)
-          Entry 1
-                  Block 2 (statement 1), line 6
-                          [ fill $color ]
+    Entry #1
+      Block #2, statement #1 (source line 6)
+        [ fill $color ]
   Scenario implicit-2-2 (validate: yes)
-          Entry 1
-                  Block 2 (statement 2), line 6
-                          [ pen $color width:2 ]
+    Entry #1
+      Block #2, statement #2 (source line 6)
+        [ pen $color width:2 ]
 # tools/IVGSnapshot/tests/ListVariableExpansion.ivg
 
 Scenario: unlabeled-1 #0

--- a/tools/IVGSnapshot/tests/ListVariableExpansion.txt
+++ b/tools/IVGSnapshot/tests/ListVariableExpansion.txt
@@ -36,11 +36,11 @@ Scenario: unlabeled-2 #1
 Summary
   Snapshots       : 4 total (4 validated)
   Updated         : 0
-  Failed          : 0 (diff failures: 0)
+  Failed          : 0 snapshots (diff failures: 0)
 
 # Overall Summary
 
-  Processed files : 1 (0 failed)
+  Processed files : 1 total (0 files reported failures)
   Snapshots       : 4 total (4 validated)
   Updated         : 0
-  Failed          : 0 (diff failures: 0)
+  Failed          : 0 snapshots (diff failures: 0)

--- a/tools/IVGSnapshot/tests/ListVariableExpansion.txt
+++ b/tools/IVGSnapshot/tests/ListVariableExpansion.txt
@@ -1,19 +1,19 @@
 tools/IVGSnapshot/tests/ListVariableExpansion.ivg
   Scenario implicit-1-1 (validate: yes)
-    Entry #1
-      Block #1, statement #1 (source line 4)
+    Scenario entry #1
+      Snapshot block #1 (block entry #1, source line 4)
         [ fill $color ]
   Scenario implicit-1-2 (validate: yes)
-    Entry #1
-      Block #1, statement #2 (source line 4)
+    Scenario entry #1
+      Snapshot block #1 (block entry #2, source line 4)
         [ pen $color width:2 ]
   Scenario implicit-2-1 (validate: yes)
-    Entry #1
-      Block #2, statement #1 (source line 6)
+    Scenario entry #1
+      Snapshot block #2 (block entry #1, source line 6)
         [ fill $color ]
   Scenario implicit-2-2 (validate: yes)
-    Entry #1
-      Block #2, statement #2 (source line 6)
+    Scenario entry #1
+      Snapshot block #2 (block entry #2, source line 6)
         [ pen $color width:2 ]
 # tools/IVGSnapshot/tests/ListVariableExpansion.ivg
 


### PR DESCRIPTION
## Summary
- wrap the NuXThreads parallel loop worker in IVGSnapshot with try/catch so interpreter failures become tracked SnapshotRunResult entries
- log the captured error details and stop when --exit-on-first-failure is active without letting exceptions escape

## Testing
- ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68f7c5ee42848332b353ee9d66389ac9