### PR TITLE
Handle PNG offsets when loading goldens

### DIFF
--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -1991,9 +1991,21 @@ loadPngRaster(const std::string &path,
 		const png_uint_32 height = png_get_image_height(png, info);
 		png_bytep *rows = png_get_rows(png, info);
 
+		png_int_32 offsetX = 0;
+		png_int_32 offsetY = 0;
+		if ((png_get_valid(png, info, PNG_INFO_oFFs) & PNG_INFO_oFFs) != 0) {
+			int offsetUnit = PNG_OFFSET_PIXEL;
+			png_get_oFFs(png, info, &offsetX, &offsetY, &offsetUnit);
+			if (offsetUnit != PNG_OFFSET_PIXEL) {
+				offsetX = 0;
+				offsetY = 0;
+			}
+		}
+
 		NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> tempRaster(
-			NuXPixels::IntRect(0, 0, static_cast<int>(width),
-							   static_cast<int>(height)));
+			NuXPixels::IntRect(static_cast<int>(offsetX), static_cast<int>(offsetY),
+				   static_cast<int>(width),
+				   static_cast<int>(height)));
 
 		for (png_uint_32 y = 0; y < height; ++y) {
 			NuXPixels::ARGB32::Pixel *dest =

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -2007,9 +2007,12 @@ loadPngRaster(const std::string &path,
 				   static_cast<int>(width),
 				   static_cast<int>(height)));
 
+		const NuXPixels::IntRect tempBounds = tempRaster.calcBounds();
+		const int tempStride = tempRaster.getStride();
+		NuXPixels::ARGB32::Pixel *const tempBase = tempRaster.getPixelPointer();
 		for (png_uint_32 y = 0; y < height; ++y) {
 			NuXPixels::ARGB32::Pixel *dest =
-				tempRaster.getPixelPointer() + y * tempRaster.getStride();
+				tempBase + (static_cast<int>(y) + tempBounds.top) * tempStride + tempBounds.left;
 			png_bytep src = rows[y];
 			for (png_uint_32 x = 0; x < width; ++x) {
 				unsigned int b = src[x * 4 + 0];


### PR DESCRIPTION
## Summary
- preserve PNG oFFs metadata when loading golden rasters so snapshot diffs honor non-zero offsets

## Testing
- timeout 600 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68fa3fd64dac8332b8c850c69d7e70b9