### PR TITLE
Fix IVGFiddle common-only snapshot execution

### DIFF
--- a/tools/ivgfiddle/src/rasterizeIVG.cpp
+++ b/tools/ivgfiddle/src/rasterizeIVG.cpp
@@ -968,20 +968,35 @@ class SnapshotExecutor : public IVGExecutorWithExternalFonts {
                 {
                 }
 
-                SnapshotExecutor(GuardedSelfContainedARGB32Canvas& canvas, const AffineTransformation& xform, const std::vector<std::string>& includeDirs, const std::string& sourcePath, SnapshotPlan& planRef, const SnapshotScenario& scenario, const SnapshotEntry& entry)
-                                : IVGExecutorWithExternalFonts(canvas, xform)
-                                , mode(SnapshotExecutorModePlayback)
-                                , plan(&planRef)
-                                , sourceText(0)
-                                , scenario(&scenario)
-                                , entry(&entry)
-                                , includeDirs(includeDirs)
-                                , sourcePath(sourcePath)
-                                , scanOffset(0)
-                                , nextBlockOrdinal(0)
-                                , invocationCursor(0)
-                {
-                }
+		SnapshotExecutor(GuardedSelfContainedARGB32Canvas& canvas, const AffineTransformation& xform, const std::vector<std::string>& includeDirs, const std::string& sourcePath, SnapshotPlan& planRef, const SnapshotScenario& scenario, const SnapshotEntry& entry)
+				: IVGExecutorWithExternalFonts(canvas, xform)
+				, mode(SnapshotExecutorModePlayback)
+				, plan(&planRef)
+				, sourceText(0)
+				, scenario(&scenario)
+				, entry(&entry)
+				, includeDirs(includeDirs)
+				, sourcePath(sourcePath)
+				, scanOffset(0)
+				, nextBlockOrdinal(0)
+				, invocationCursor(0)
+		{
+		}
+
+		SnapshotExecutor(GuardedSelfContainedARGB32Canvas& canvas, const AffineTransformation& xform, const std::vector<std::string>& includeDirs, const std::string& sourcePath, SnapshotPlan& planRef)
+				: IVGExecutorWithExternalFonts(canvas, xform)
+				, mode(SnapshotExecutorModePlayback)
+				, plan(&planRef)
+				, sourceText(0)
+				, scenario(0)
+				, entry(0)
+				, includeDirs(includeDirs)
+				, sourcePath(sourcePath)
+				, scanOffset(0)
+				, nextBlockOrdinal(0)
+				, invocationCursor(0)
+		{
+		}
 
 bool load(Interpreter& interpreter, const WideString& filename, String& contents)
 {
@@ -1092,7 +1107,14 @@ return false;
                                 Interpreter::throwBadSyntax("snapshot common block changed between collection and playback.");
                         }
 
-                        const bool blockTargetsScenario = (scenario->explicitScenario ? (hasLabel && *scenarioLabel == scenario->name) : (!hasLabel && scenarioInvocation != 0));
+			bool blockTargetsScenario = false;
+			if (scenario != 0) {
+				if (scenario->explicitScenario) {
+					blockTargetsScenario = (hasLabel && *scenarioLabel == scenario->name);
+				} else {
+					blockTargetsScenario = (!hasLabel && scenarioInvocation != 0);
+				}
+			}
                         const String* listArg = args.fetchOptional("list", false);
                         StringVector statements;
                         if (listArg != 0) {
@@ -1433,25 +1455,29 @@ uint8_t* rasterizeIVG(const char* ivgSource, double scaling, int scenarioIndex, 
 		{
 			STLMapVariables topVars;
 			FormatInfo formatInfo;
-			if (selectedScenarioIndex != sentinel && selectedEntryOrdinal != sentinel) {
-				const SnapshotScenario& scenario = scenarios[selectedScenarioIndex];
-				if (selectedEntryOrdinal - 1 < scenario.entryIndices.size()) {
-					const uint32_t entryIndex = scenario.entryIndices[selectedEntryOrdinal - 1];
-					if (entryIndex < entries.size()) {
-						const SnapshotEntry& entry = entries[entryIndex];
-                                               SnapshotExecutor executor(canvas, AffineTransformation().scale(scaling), includeDirs, SNAPSHOT_SOURCE_PATH, snapshotPlan, scenario, entry);
-                                                Interpreter impd(executor, topVars, formatInfo);
-                                                impd.run(StringRange(sourceString));
-                                                if (!executor.finished()) {
-                                                        throw runtime_error("Snapshot playback did not execute all invocations.");
-                                                }
+				if (selectedScenarioIndex != sentinel && selectedEntryOrdinal != sentinel) {
+					const SnapshotScenario& scenario = scenarios[selectedScenarioIndex];
+					if (selectedEntryOrdinal - 1 < scenario.entryIndices.size()) {
+						const uint32_t entryIndex = scenario.entryIndices[selectedEntryOrdinal - 1];
+						if (entryIndex < entries.size()) {
+							const SnapshotEntry& entry = entries[entryIndex];
+							SnapshotExecutor executor(canvas, AffineTransformation().scale(scaling), includeDirs, SNAPSHOT_SOURCE_PATH, snapshotPlan, scenario, entry);
+							Interpreter impd(executor, topVars, formatInfo);
+							impd.run(StringRange(sourceString));
+							if (!executor.finished()) {
+								throw runtime_error("Snapshot playback did not execute all invocations.");
+							}
+						}
 					}
+				} else if (snapshotPlan.hasCommonBlocks()) {
+					SnapshotExecutor executor(canvas, AffineTransformation().scale(scaling), includeDirs, SNAPSHOT_SOURCE_PATH, snapshotPlan);
+					Interpreter impd(executor, topVars, formatInfo);
+					impd.run(StringRange(sourceString));
+				} else {
+					IVGExecutorWithExternalFonts ivgExecutor(canvas, AffineTransformation().scale(scaling));
+					Interpreter impd(ivgExecutor, topVars, formatInfo);
+					impd.run(StringRange(sourceString));
 				}
-			} else {
-				IVGExecutorWithExternalFonts ivgExecutor(canvas, AffineTransformation().scale(scaling));
-				Interpreter impd(ivgExecutor, topVars, formatInfo);
-				impd.run(StringRange(sourceString));
-			}
 		}
 
 		SelfContainedRaster<ARGB32>* raster = canvas.accessRaster();

--- a/tools/ivgfiddle/testIVGFiddle.js
+++ b/tools/ivgfiddle/testIVGFiddle.js
@@ -114,4 +114,26 @@ test("WebAssembly snapshot catalog playback honors selections", async () => {
 	assert.equal(variantResult.selectedEntryOrdinal, 2);
 });
 
+test("WebAssembly executes common-only snapshot blocks", async () => {
+	const Module = await createModule();
+	const source = [
+		"format IVG-3 requires:IMPD-1 uses:snapshot-1",
+		"bounds 0,0,1,1",
+		"meta snapshot common:[ c=#336699 ]",
+		"wipe $c",
+		"",
+	].join("\n");
+	const size = Module.lengthBytesUTF8(source) + 1;
+	const ptr = Module._malloc(size);
+	Module.stringToUTF8(source, ptr, size);
+	const rasterPtr = Module._rasterizeIVG(ptr, 1);
+	Module._free(ptr);
+	assert.notEqual(rasterPtr, 0, "common-only raster failed");
+	const result = decodeRasterResult(Module, rasterPtr);
+	Module._deallocatePixels(rasterPtr);
+	assert.deepEqual(result.firstPixel, [0x33, 0x66, 0x99, 0xFF], "wipe should apply shared color");
+	assert.equal(result.catalog.hasCommon, true);
+	assert.equal(result.catalog.hasCommonOnly, true);
+});
+
 


### PR DESCRIPTION
## Summary
- ensure the snapshot executor can run without a scenario entry so common-only blocks execute
- fall back to snapshot playback when only shared code exists and add coverage for the regression

## Testing
- `timeout 600 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6907702edc648332bf3d331c5aba2e84