### PR TITLE
Fix golden audit base matching and add regression test

### DIFF
--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -1332,6 +1332,52 @@ static void removeFileIfExists(const std::string &path) {
 	}
 }
 
+
+static void collectOrphanGoldens(const std::set<std::string> &processedBases,
+		const std::set<std::string> &auditRoots,
+		std::vector<std::string> &orphanGoldens) {
+	orphanGoldens.clear();
+	for (std::set<std::string>::const_iterator it = auditRoots.begin();
+		it != auditRoots.end(); ++it) {
+		const std::string &root = *it;
+		if (root.empty()) {
+			continue;
+		}
+		const std::string wildcard = joinPath(root, std::string("*__*.png"));
+		try {
+			std::vector<NuXFiles::Path> matches;
+			NuXFiles::Path::findPaths(matches, pathStringToWide(wildcard));
+			for (size_t k = 0; k < matches.size(); ++k) {
+				const NuXFiles::Path &p = matches[k];
+				const std::wstring name = p.getName();
+				std::string narrow = pathStringFromWide(name);
+				bool matchedBase = false;
+				for (std::set<std::string>::const_iterator baseIt = processedBases.begin();
+					baseIt != processedBases.end(); ++baseIt) {
+					const std::string &base = *baseIt;
+					if (base.empty()) {
+						continue;
+					}
+					const size_t baseLength = base.size();
+					if (narrow.size() <= baseLength + 2) {
+						continue;
+					}
+					if (narrow.compare(0, baseLength, base) == 0 &&
+						narrow.compare(baseLength, 2, "__") == 0) {
+						matchedBase = true;
+						break;
+					}
+				}
+				if (!matchedBase) {
+					orphanGoldens.push_back(pathStringFromWide(p.getFullPath()));
+				}
+			}
+		} catch (...) {
+			// Ignore listing errors; best-effort audit only.
+		}
+	}
+}
+
 static bool renameFile(const std::string &from, const std::string &to,
 					   std::string &error) {
 	if (from.empty() || from == to) {
@@ -3377,33 +3423,7 @@ int main(int argc, char **argv) {
 			}
 
 			std::vector<std::string> orphanGoldens;
-			for (std::set<std::string>::const_iterator it = auditRoots.begin();
-				 it != auditRoots.end(); ++it) {
-				const std::string &root = *it;
-				if (root.empty()) {
-					continue;
-				}
-				const std::string wildcard = joinPath(root, std::string("*__*.png"));
-				try {
-					std::vector<NuXFiles::Path> matches;
-					NuXFiles::Path::findPaths(matches, pathStringToWide(wildcard));
-					for (size_t k = 0; k < matches.size(); ++k) {
-						const NuXFiles::Path &p = matches[k];
-						const std::wstring name = p.getName(); // without extension
-						std::string narrow = pathStringFromWide(name);
-						const size_t sep = narrow.find("__");
-						if (sep == std::string::npos) {
-							continue;
-						}
-						const std::string base = narrow.substr(0, sep);
-						if (processedBases.find(base) == processedBases.end()) {
-							orphanGoldens.push_back(pathStringFromWide(p.getFullPath()));
-						}
-					}
-				} catch (...) {
-					// Ignore listing errors; best-effort audit only.
-				}
-			}
+			collectOrphanGoldens(processedBases, auditRoots, orphanGoldens);
 
 			if (!orphanGoldens.empty()) {
 				for (size_t i = 0; i < orphanGoldens.size(); ++i) {

--- a/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
+++ b/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
@@ -311,6 +311,59 @@ void TestSnapshotSourceTags()
                 "outside root should sanitize absolute path");
 }
 
+void TestGoldenAuditWithSanitizedBases()
+{
+	char tempName[L_tmpnam];
+	if (std::tmpnam(tempName) == 0) {
+		Fail("failed to allocate temporary audit root");
+	}
+	std::string root(tempName);
+	root += "_ivgsnapshot_audit";
+	Expect(ensureDirectory(root), "create audit root");
+	const std::string alpha = joinPath(root, "alpha");
+	Expect(ensureDirectory(alpha), "create alpha directory");
+	const std::string beta = joinPath(alpha, "beta");
+	Expect(ensureDirectory(beta), "create beta directory");
+
+	const std::string ivgPath = joinPath(beta, "sample.ivg");
+	{
+		std::ofstream file(ivgPath.c_str(), std::ios::binary);
+		if (!file.good()) {
+			Fail(std::string("failed to write temporary IVG: ") + ivgPath);
+		}
+		file << "format ivg-3 uses:snapshot-1\n";
+		file << "bounds 0,0,1,1\n";
+		file << "meta snapshot scenario:document [ fill red ]\n";
+	}
+
+	const NuXFiles::Path rootPath = pathFromNativeString(root);
+	Expect(!rootPath.isNull(), "audit root path should be valid");
+	const std::string snapshotBase = buildSnapshotSourceTag(ivgPath, rootPath);
+	Expect(!snapshotBase.empty(), "snapshot base should not be empty");
+
+	const std::string goldenPath = joinPath(beta, snapshotBase + "__document.png");
+	{
+		std::ofstream golden(goldenPath.c_str(), std::ios::binary);
+		if (!golden.good()) {
+			Fail(std::string("failed to write temporary golden: ") + goldenPath);
+		}
+		golden.put('\0');
+	}
+
+	std::set<std::string> processedBases;
+	processedBases.insert(snapshotBase);
+
+	std::set<std::string> auditRoots;
+	auditRoots.insert(beta);
+
+	std::vector<std::string> orphanGoldens;
+	collectOrphanGoldens(processedBases, auditRoots, orphanGoldens);
+	Expect(orphanGoldens.empty(), "sanitized golden should not be orphan");
+
+	removeFileIfExists(ivgPath);
+	removeFileIfExists(goldenPath);
+}
+
 void TestDraftValidateWorkflow()
 {
         const char *tempEnv = std::getenv("TMPDIR");
@@ -378,15 +431,16 @@ void TestDraftValidateWorkflow()
 
 int main()
 {
-        TestListOnlySample();
-        TestListScenarioVariants();
-        TestListVariableExpansion();
-        TestCommonBlockListOnly();
-        TestCommonBlockMismatchDetection();
-        TestScenarioMismatchDetection();
-        TestImplicitSnapshotRendering();
-        TestValidateMismatch();
-        TestSnapshotSourceTags();
-        TestDraftValidateWorkflow();
-        return 0;
+	TestListOnlySample();
+	TestListScenarioVariants();
+	TestListVariableExpansion();
+	TestCommonBlockListOnly();
+	TestCommonBlockMismatchDetection();
+	TestScenarioMismatchDetection();
+	TestImplicitSnapshotRendering();
+	TestValidateMismatch();
+	TestSnapshotSourceTags();
+	TestGoldenAuditWithSanitizedBases();
+	TestDraftValidateWorkflow();
+	return 0;
 }


### PR DESCRIPTION
## Summary
- update the golden audit to recognise snapshot bases that contain escaped directory separators
- add a regression test that reproduces the orphaned golden detection scenario and ensure the audit helper is exercised from the test suite

## Testing
- timeout 600 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_6908926903e483328ad8bded8e3c1dbd