### PR TITLE
Respect PNG offsets when reading snapshot goldens

### DIFF
--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -1884,6 +1884,10 @@ class SnapshotGolden {
 
 		const NuXPixels::IntRect actualBounds = raster.calcBounds();
 		const NuXPixels::IntRect goldenBounds = goldenRaster.calcBounds();
+		const bool boundsMatch = (actualBounds.left == goldenBounds.left &&
+			actualBounds.top == goldenBounds.top &&
+			actualBounds.width == goldenBounds.width &&
+			actualBounds.height == goldenBounds.height);
 		const int left =
 			NuXPixels::minValue(actualBounds.left, goldenBounds.left);
 		const int top = NuXPixels::minValue(actualBounds.top, goldenBounds.top);
@@ -1919,7 +1923,7 @@ class SnapshotGolden {
 		uint64_t sumRed = 0;
 		uint64_t sumGreen = 0;
 		uint64_t sumBlue = 0;
-		bool match = true;
+		bool match = boundsMatch;
 
 		for (int y = top; y < bottom; ++y) {
 			NuXPixels::ARGB32::Pixel *diffRow = diffPixels + y * diffStride;
@@ -1932,16 +1936,43 @@ class SnapshotGolden {
 					? goldenPixelsPtr + y * goldenStride
 					: 0;
 			for (int x = left; x < right; ++x) {
-				const NuXPixels::ARGB32::Pixel actualPixel =
+				const bool actualContains =
 					(actualRow != 0 && x >= actualBounds.left &&
-					 x < actualBounds.calcRight())
-						? actualRow[x]
-						: 0;
-				const NuXPixels::ARGB32::Pixel goldenPixel =
+					 x < actualBounds.calcRight());
+				const bool goldenContains =
 					(goldenRow != 0 && x >= goldenBounds.left &&
-					 x < goldenBounds.calcRight())
-						? goldenRow[x]
-						: 0;
+					 x < goldenBounds.calcRight());
+				if (actualContains != goldenContains) {
+					match = false;
+					++stats.differingPixels;
+					const unsigned int highlightA = 0xFFu;
+					const unsigned int highlightR = actualContains ? 0xFFu : 0u;
+					const unsigned int highlightG = actualContains ? 0u : 0xFFu;
+					const unsigned int highlightB = 0u;
+					diffRow[x] = (highlightA << 24) | (highlightR << 16)
+						| (highlightG << 8) | highlightB;
+					sumAlpha += highlightA;
+					sumRed += highlightR;
+					sumGreen += highlightG;
+					sumBlue += highlightB;
+					if (highlightA > stats.maxAlphaDiff) {
+						stats.maxAlphaDiff = highlightA;
+					}
+					if (highlightR > stats.maxRedDiff) {
+						stats.maxRedDiff = highlightR;
+					}
+					if (highlightG > stats.maxGreenDiff) {
+						stats.maxGreenDiff = highlightG;
+					}
+					if (highlightB > stats.maxBlueDiff) {
+						stats.maxBlueDiff = highlightB;
+					}
+					continue;
+				}
+				const NuXPixels::ARGB32::Pixel actualPixel =
+					actualContains ? actualRow[x] : 0;
+				const NuXPixels::ARGB32::Pixel goldenPixel =
+					goldenContains ? goldenRow[x] : 0;
 				if (actualPixel == goldenPixel) {
 					diffRow[x] = 0;
 					continue;
@@ -2021,6 +2052,13 @@ class SnapshotGolden {
 		std::ostringstream summary;
 		summary << "differs from golden (pixels: " << stats.differingPixels
 				<< "/" << (stats.width * stats.height) << ")";
+		if (!boundsMatch) {
+			summary << ", bounds differ (actual " << actualBounds.left << ","
+				<< actualBounds.top << " " << actualBounds.width << "x"
+				<< actualBounds.height << " vs golden " << goldenBounds.left << ","
+				<< goldenBounds.top << " " << goldenBounds.width << "x"
+				<< goldenBounds.height << ")";
+		}
 		result.message = summary.str();
 
 		removeFileIfExists(actualPath);

--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -39,6 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iomanip>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <locale>
 #include <map>
 #include <set>
@@ -2129,15 +2130,43 @@ loadPngRaster(const std::string &path,
 		png_read_png(png, info, PNG_TRANSFORM_EXPAND, 0);
 		const png_uint_32 width = png_get_image_width(png, info);
 		const png_uint_32 height = png_get_image_height(png, info);
-		png_bytep *rows = png_get_rows(png, info);
+		if (width > static_cast<png_uint_32>(std::numeric_limits<int>::max())
+				|| height > static_cast<png_uint_32>(std::numeric_limits<int>::max())) {
+			throw std::runtime_error("PNG dimensions exceed supported range");
+		}
+
+		png_int_32 rawOffsetX = 0;
+		png_int_32 rawOffsetY = 0;
+		int offsetUnit = PNG_OFFSET_PIXEL;
+		bool hasPixelOffsets = false;
+		if (png_get_valid(png, info, PNG_INFO_oFFs)) {
+			(void)png_get_oFFs(png, info, &rawOffsetX, &rawOffsetY, &offsetUnit);
+			hasPixelOffsets = (offsetUnit == PNG_OFFSET_PIXEL);
+		}
+
+		int left = 0;
+		int top = 0;
+		if (hasPixelOffsets) {
+			if (rawOffsetX < static_cast<png_int_32>(std::numeric_limits<int>::min())
+				|| rawOffsetX > static_cast<png_int_32>(std::numeric_limits<int>::max())
+				|| rawOffsetY < static_cast<png_int_32>(std::numeric_limits<int>::min())
+				|| rawOffsetY > static_cast<png_int_32>(std::numeric_limits<int>::max())) {
+				throw std::runtime_error("PNG offsets exceed supported range");
+			}
+			left = static_cast<int>(rawOffsetX);
+			top = static_cast<int>(rawOffsetY);
+		}
 
 		NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> tempRaster(
-			NuXPixels::IntRect(0, 0, static_cast<int>(width),
-							   static_cast<int>(height)));
+				NuXPixels::IntRect(left, top, static_cast<int>(width),
+								static_cast<int>(height)));
+
+		png_bytep *rows = png_get_rows(png, info);
 
 		for (png_uint_32 y = 0; y < height; ++y) {
+			const int targetY = top + static_cast<int>(y);
 			NuXPixels::ARGB32::Pixel *dest =
-				tempRaster.getPixelPointer() + y * tempRaster.getStride();
+					tempRaster.getPixelPointer() + targetY * tempRaster.getStride();
 			png_bytep src = rows[y];
 			for (png_uint_32 x = 0; x < width; ++x) {
 				unsigned int b = src[x * 4 + 0];
@@ -2149,7 +2178,8 @@ loadPngRaster(const std::string &path,
 					g = convertStraightChannelToPremultiplied(g, a);
 					b = convertStraightChannelToPremultiplied(b, a);
 				}
-				dest[x] = (a << 24) | (r << 16) | (g << 8) | b;
+				const int targetX = left + static_cast<int>(x);
+				dest[targetX] = (a << 24) | (r << 16) | (g << 8) | b;
 			}
 		}
 

--- a/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
+++ b/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
@@ -427,6 +427,145 @@ void TestDraftValidateWorkflow()
         removeFileIfExists(paths.oldPath);
 }
 
+
+void TestPngOffsetsRoundTrip()
+{
+	char tempName[L_tmpnam];
+	Expect(std::tmpnam(tempName) != 0,
+		"failed to allocate temporary PNG name");
+	std::string path(tempName);
+	path += ".png";
+
+	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> raster(
+		NuXPixels::IntRect(11, 13, 4, 3));
+	const NuXPixels::IntRect bounds = raster.calcBounds();
+	for (int y = bounds.top; y < bounds.calcBottom(); ++y) {
+		for (int x = bounds.left; x < bounds.calcRight(); ++x) {
+			raster.setPixel(x, y, 0xFF336699u);
+		}
+	}
+
+	std::string error;
+	Expect(writeRasterToPng(path, raster, error),
+		"writeRasterToPng should succeed");
+	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> loaded;
+	Expect(loadPngRaster(path, loaded),
+		"loadPngRaster should succeed");
+	Expect(loaded.calcBounds() == bounds,
+		"loaded bounds should match original");
+	Expect(loaded.getPixel(bounds.left, bounds.top) == 0xFF336699u,
+		"loaded pixel should match original color");
+
+	removeFileIfExists(path);
+}
+
+void TestSnapshotValidationWithOffsets()
+{
+	char tempName[L_tmpnam];
+	Expect(std::tmpnam(tempName) != 0,
+		"failed to allocate temporary snapshot directory");
+	std::string root(tempName);
+	root += "_offset_validate";
+	Expect(ensureDirectory(root), "create snapshot directory");
+
+	CommandLineOptions options;
+	options.snapshotDir = root;
+
+	SnapshotGolden golden("offset.ivg", "offset_base",
+		"offsetScenario", options);
+
+	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> raster(
+		NuXPixels::IntRect(7, 9, 6, 5));
+	const NuXPixels::IntRect bounds = raster.calcBounds();
+	for (int y = bounds.top; y < bounds.calcBottom(); ++y) {
+		for (int x = bounds.left; x < bounds.calcRight(); ++x) {
+			raster.setPixel(x, y, 0xFF123456u);
+		}
+	}
+
+	SnapshotEntryResult first;
+	Expect(golden.validate(raster, true, first),
+		"force update should succeed");
+	Expect(first.success, "force update result success flag");
+	Expect(first.updated, "force update should mark updated");
+	Expect(fileExists(first.goldenPath),
+		"golden PNG should be written with offsets");
+
+	SnapshotEntryResult second;
+	Expect(golden.validate(raster, false, second),
+		"validate should succeed with matching offsets");
+	Expect(second.success, "second validate result success flag");
+	Expect(!second.diffed, "second validate should not diff");
+	Expect(!second.updated, "second validate should not update");
+	Expect(second.message.empty(),
+		"second validate should not produce a message");
+
+	removeFileIfExists(second.goldenPath);
+	removeFileIfExists(second.actualPath);
+	removeFileIfExists(second.diffPath);
+	removeFileIfExists(second.backupPath);
+	removeFileIfExists(first.backupPath);
+	removeFileIfExists(first.oldPath);
+}
+
+void TestSnapshotDetectsOffsetMismatch()
+{
+	char tempName[L_tmpnam];
+	Expect(std::tmpnam(tempName) != 0,
+		"failed to allocate mismatch snapshot directory");
+	std::string root(tempName);
+	root += "_offset_mismatch";
+	Expect(ensureDirectory(root), "create mismatch snapshot directory");
+
+	CommandLineOptions options;
+	options.snapshotDir = root;
+
+	SnapshotGolden golden("mismatch.ivg", "offset_base",
+		"offsetScenario", options);
+
+	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> baseline(
+		NuXPixels::IntRect(4, 6, 5, 4));
+	const NuXPixels::IntRect baselineBounds = baseline.calcBounds();
+	for (int y = baselineBounds.top; y < baselineBounds.calcBottom(); ++y) {
+		for (int x = baselineBounds.left; x < baselineBounds.calcRight(); ++x) {
+			baseline.setPixel(x, y, 0xFF89ABC0u);
+		}
+	}
+
+	SnapshotEntryResult baselineResult;
+	Expect(golden.validate(baseline, true, baselineResult),
+		"baseline force update should succeed");
+	Expect(baselineResult.success, "baseline success flag");
+
+	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> shifted(
+		NuXPixels::IntRect(4, 7, 5, 4));
+	const NuXPixels::IntRect shiftedBounds = shifted.calcBounds();
+	for (int y = shiftedBounds.top; y < shiftedBounds.calcBottom(); ++y) {
+		for (int x = shiftedBounds.left; x < shiftedBounds.calcRight(); ++x) {
+			shifted.setPixel(x, y, 0xFF89ABC0u);
+		}
+	}
+
+	SnapshotEntryResult mismatch;
+	Expect(!golden.validate(shifted, false, mismatch),
+		"mismatched offsets should fail validation");
+	Expect(!mismatch.success, "mismatch success flag should be false");
+	Expect(mismatch.diffed, "mismatch should record diff output");
+	Expect(mismatch.message.find("differs from golden") != std::string::npos,
+		"mismatch should report diff message");
+	Expect(fileExists(mismatch.actualPath),
+		"actual PNG should be written on mismatch");
+	Expect(fileExists(mismatch.diffPath),
+		"diff PNG should be written on mismatch");
+
+	removeFileIfExists(mismatch.goldenPath);
+	removeFileIfExists(mismatch.actualPath);
+	removeFileIfExists(mismatch.diffPath);
+	removeFileIfExists(mismatch.backupPath);
+	removeFileIfExists(baselineResult.backupPath);
+	removeFileIfExists(baselineResult.oldPath);
+}
+
 } // namespace
 
 int main()
@@ -442,5 +581,8 @@ int main()
 	TestSnapshotSourceTags();
 	TestGoldenAuditWithSanitizedBases();
 	TestDraftValidateWorkflow();
+	TestPngOffsetsRoundTrip();
+	TestSnapshotValidationWithOffsets();
+	TestSnapshotDetectsOffsetMismatch();
 	return 0;
 }

--- a/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
+++ b/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
@@ -553,10 +553,71 @@ void TestSnapshotDetectsOffsetMismatch()
 	Expect(mismatch.diffed, "mismatch should record diff output");
 	Expect(mismatch.message.find("differs from golden") != std::string::npos,
 		"mismatch should report diff message");
+	Expect(mismatch.message.find("bounds differ") != std::string::npos,
+		"mismatch should explain bounds difference");
 	Expect(fileExists(mismatch.actualPath),
 		"actual PNG should be written on mismatch");
 	Expect(fileExists(mismatch.diffPath),
 		"diff PNG should be written on mismatch");
+
+	removeFileIfExists(mismatch.goldenPath);
+	removeFileIfExists(mismatch.actualPath);
+	removeFileIfExists(mismatch.diffPath);
+	removeFileIfExists(mismatch.backupPath);
+	removeFileIfExists(baselineResult.backupPath);
+	removeFileIfExists(baselineResult.oldPath);
+}
+
+void TestSnapshotDetectsBoundsMismatch()
+{
+	char tempName[L_tmpnam];
+	Expect(std::tmpnam(tempName) != 0,
+		"failed to allocate bounds mismatch snapshot directory");
+	std::string root(tempName);
+	root += "_bounds_mismatch";
+	Expect(ensureDirectory(root),
+		"create bounds mismatch snapshot directory");
+
+	CommandLineOptions options;
+	options.snapshotDir = root;
+
+	SnapshotGolden golden("bounds.ivg", "bounds_base",
+		"boundsScenario", options);
+
+	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> baseline(
+		NuXPixels::IntRect(2, 3, 4, 4));
+	const NuXPixels::IntRect baselineBounds = baseline.calcBounds();
+	for (int y = baselineBounds.top; y < baselineBounds.calcBottom(); ++y) {
+		for (int x = baselineBounds.left; x < baselineBounds.calcRight(); ++x) {
+			baseline.setPixel(x, y, 0u);
+		}
+	}
+
+	SnapshotEntryResult baselineResult;
+	Expect(golden.validate(baseline, true, baselineResult),
+		"baseline force update should succeed");
+	Expect(baselineResult.success, "baseline success flag");
+
+	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> expanded(
+		NuXPixels::IntRect(6, 7, 4, 4));
+	const NuXPixels::IntRect expandedBounds = expanded.calcBounds();
+	for (int y = expandedBounds.top; y < expandedBounds.calcBottom(); ++y) {
+		for (int x = expandedBounds.left; x < expandedBounds.calcRight(); ++x) {
+			expanded.setPixel(x, y, 0u);
+		}
+	}
+
+	SnapshotEntryResult mismatch;
+	Expect(!golden.validate(expanded, false, mismatch),
+		"bounds mismatch should fail validation");
+	Expect(!mismatch.success,
+		"bounds mismatch success flag should be false");
+	Expect(mismatch.diffed,
+		"bounds mismatch should produce diff output");
+	Expect(mismatch.diffStats.differingPixels > 0,
+		"bounds mismatch should report differing pixels");
+	Expect(mismatch.message.find("bounds differ") != std::string::npos,
+		"bounds mismatch should explain bounds difference");
 
 	removeFileIfExists(mismatch.goldenPath);
 	removeFileIfExists(mismatch.actualPath);
@@ -584,5 +645,6 @@ int main()
 	TestPngOffsetsRoundTrip();
 	TestSnapshotValidationWithOffsets();
 	TestSnapshotDetectsOffsetMismatch();
+	TestSnapshotDetectsBoundsMismatch();
 	return 0;
 }


### PR DESCRIPTION
## Summary
- preserve PNG offset metadata when loading snapshot goldens so rasters compare in the correct coordinate space
- add regression coverage for PNG offsets in the snapshot test plan, including successful validation and mismatch detection

## Testing
- timeout 600 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_6908d229de18833281bc33a771833a54