### PR TITLE
Fix relative snapshot directory handling

### DIFF
--- a/tools/IVGSnapshot/IVGSnapshot.cpp
+++ b/tools/IVGSnapshot/IVGSnapshot.cpp
@@ -2896,7 +2896,22 @@ static bool parseCommandLine(int argc, char **argv,
 				std::cerr << "--snapshot-dir requires a path." << std::endl;
 				return false;
 			}
-			options.snapshotDir = argv[++i];
+			const std::string snapshotArgument(argv[++i]);
+			const NuXFiles::Path snapshotPath =
+				pathFromNativeString(snapshotArgument);
+			if (snapshotPath.isNull()) {
+				std::cerr << "failed to parse snapshot directory: "
+						<< snapshotArgument << std::endl;
+				return false;
+			}
+			try {
+				options.snapshotDir =
+					pathStringFromWide(snapshotPath.getFullPath());
+			} catch (const std::exception &) {
+				std::cerr << "failed to resolve snapshot directory: "
+						<< snapshotArgument << std::endl;
+				return false;
+			}
 		} else if (arg == "--root-dir") {
 			if (i + 1 >= argc) {
 				std::cerr << "--root-dir requires a path." << std::endl;

--- a/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
+++ b/tools/IVGSnapshot/tests/TestSnapshotPlan.cpp
@@ -459,6 +459,82 @@ void TestPngOffsetsRoundTrip()
 	removeFileIfExists(path);
 }
 
+void TestRelativeSnapshotDirectory()
+{
+	const std::string baseDir = "RelativeSnapshotTest";
+	Expect(ensureDirectory(baseDir), "create base directory");
+	const std::string childDir = joinPath(baseDir, "child");
+	Expect(ensureDirectory(childDir), "create child directory");
+
+	const std::string ivgRelative = joinPath(childDir, "relative.ivg");
+	{
+		std::ofstream file(ivgRelative.c_str(), std::ios::binary);
+		Expect(file.good(), "open relative IVG for writing");
+		file << "format ivg-3 uses:snapshot-1\n";
+		file << "bounds 0,0,1,1\n";
+		file << "meta snapshot scenario:document [ fill white ]\n";
+	}
+
+	const NuXFiles::Path ivgPathObj = pathFromNativeString(ivgRelative);
+	Expect(!ivgPathObj.isNull(), "relative IVG path should resolve");
+	std::string ivgPath;
+	try {
+		ivgPath = pathStringFromWide(ivgPathObj.getFullPath());
+	} catch (const std::exception &) {
+		Fail("failed to canonicalize relative IVG path");
+	}
+
+	const std::string snapshotDirArgument = joinPath(childDir, "..");
+	std::vector<std::string> args;
+	args.push_back("IVGSnapshotTest");
+	args.push_back("--snapshot-dir");
+	args.push_back(snapshotDirArgument);
+	args.push_back(ivgPath);
+	std::vector<char *> argv(args.size());
+	for (size_t i = 0; i < args.size(); ++i) {
+		argv[i] = &args[i][0];
+	}
+	CommandLineOptions options;
+	Expect(parseCommandLine(static_cast<int>(args.size()), &argv[0], options),
+			"parse relative snapshot directory");
+
+	const std::string snapshotBase =
+			buildSnapshotSourceTag(ivgPath, options.rootDir);
+	NuXPixels::SelfContainedRaster<NuXPixels::ARGB32> raster(
+		NuXPixels::IntRect(0, 0, 1, 1));
+	raster.getPixelPointer()[0] = 0xFFFFFFFFu;
+	SnapshotGolden golden(ivgPath, snapshotBase, "document", options);
+
+	SnapshotEntryResult updateResult;
+	Expect(golden.validate(raster, true, updateResult),
+			"force update with relative snapshot dir");
+	Expect(updateResult.success, "relative force update success flag");
+
+	SnapshotEntryResult validateResult;
+	Expect(golden.validate(raster, false, validateResult),
+			"validate with relative snapshot dir");
+	Expect(validateResult.success, "relative validate success flag");
+	Expect(!validateResult.updated, "relative validate should not update");
+
+	removeFileIfExists(updateResult.goldenPath);
+	removeFileIfExists(updateResult.oldPath);
+	removeFileIfExists(updateResult.actualPath);
+	removeFileIfExists(updateResult.diffPath);
+	removeFileIfExists(updateResult.backupPath);
+	removeFileIfExists(validateResult.actualPath);
+	removeFileIfExists(validateResult.diffPath);
+	removeFileIfExists(validateResult.backupPath);
+	std::remove(ivgPath.c_str());
+	const NuXFiles::Path childPath = pathFromNativeString(childDir);
+	if (!childPath.isNull()) {
+		childPath.tryToErase();
+	}
+	const NuXFiles::Path basePath = pathFromNativeString(baseDir);
+	if (!basePath.isNull()) {
+		basePath.tryToErase();
+	}
+}
+
 void TestSnapshotValidationWithOffsets()
 {
 	char tempName[L_tmpnam];
@@ -643,6 +719,7 @@ int main()
 	TestGoldenAuditWithSanitizedBases();
 	TestDraftValidateWorkflow();
 	TestPngOffsetsRoundTrip();
+	TestRelativeSnapshotDirectory();
 	TestSnapshotValidationWithOffsets();
 	TestSnapshotDetectsOffsetMismatch();
 	TestSnapshotDetectsBoundsMismatch();


### PR DESCRIPTION
## Summary
- canonicalize `--snapshot-dir` arguments so they resolve to absolute paths
- add a regression test to exercise relative snapshot directories

## Testing
- ./build.sh

------
https://chatgpt.com/codex/tasks/task_b_690a1bdebf4c832e824fa13e3df10903